### PR TITLE
Daniel

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ The following code is a simple example to generate the one-loop 4-point vertex f
 using FeynmanDiagram
 
 # Define a parameter structure for the 4-vertex diagram with one-loop, in the momentum and the imaginary-time representation. Require the diagrams to be green's function irreducible.
-para = DiagParaF64(type = Ver4Diag, innerLoopNum = 1,hasTau = true, filter=[NoHatree, Girreducible,])
+para = DiagParaF64(type = Ver4Diag, innerLoopNum = 1,hasTau = true, filter=[NoHartree, Girreducible,])
+para = DiagParaF64(type = Ver4Diag, innerLoopNum = 1,hasTau = true, filter=[NoHartree, Girreducible,])
 
 ver4=Parquet.build(para) #build the diagram tree with the parquet algorithm.
 

--- a/src/FeynmanDiagram.jl
+++ b/src/FeynmanDiagram.jl
@@ -18,7 +18,7 @@ function Base.iterate(r::DiagramType, ::Nothing) end
 @enum Filter begin
     Wirreducible  #remove all polarization subdiagrams
     Girreducible  #remove all self-energy inseration
-    NoHatree
+    NoHartree
     NoFock
     NoBubble  # true to remove all bubble subdiagram
     Proper  #ver4, ver3, and polarization diagrams may require to be irreducible along the transfer momentum/frequency
@@ -55,7 +55,7 @@ function Base.iterate(r::AnalyticProperty, ::Nothing) end
 
 export SigmaDiag, PolarDiag, Ver3Diag, Ver4Diag, GreenDiag
 export VacuumDiag, GnDiag, GcDiag
-export Wirreducible, Girreducible, NoBubble, NoHatree, NoFock, Proper
+export Wirreducible, Girreducible, NoBubble, NoHartree, NoFock, Proper
 export Response, ChargeCharge, SpinSpin, UpUp, UpDown
 export AnalyticProperty, Instant, Dynamic, D_Instant, D_Dynamic
 
@@ -118,10 +118,10 @@ if ccall(:jl_generating_output, Cint, ()) == 1   # if we're precompiling the pac
         # Parquet.vertex3(para)  # this will force precompilation
         Parquet.build(para)  # this will force precompilation
 
-        DiagTree.removeHatreeFock!(ver4.diagram)
+        DiagTree.removeHartreeFock!(ver4.diagram)
         DiagTree.derivative(ver4.diagram, BareGreenId)
         DiagTree.derivative(ver4.diagram, BareInteractionId)
-        # DiagTree.removeHatreeFock!(ver4.diagram)
+        # DiagTree.removeHartreeFock!(ver4.diagram)
         ExprTree.build(ver4.diagram)
     end
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -71,7 +71,7 @@ end
     totalTauNum::Int = firstTauIdx + innerTauNum(type, innerLoopNum, interactionTauNum(hasTau, interaction)) - 1
     #if there is no imaginary-time at all, then set this number to zero!
     ########################################################################
-    filter::Vector{Filter} = [NoHatree,] #usually, the Hatree subdiagram should be removed
+    filter::Vector{Filter} = [NoHartree,] #usually, the Hartree subdiagram should be removed
     transferLoop::Vector{Float64} = [] #Set it to be the transfer momentum/frequency if you want to check the diagrams are proper or not
     extra::Any = Nothing
 end

--- a/src/diagram_tree/common.jl
+++ b/src/diagram_tree/common.jl
@@ -1,7 +1,7 @@
 import ..Filter
 import ..Wirreducible  #remove all polarization subdiagrams
 import ..Girreducible  #remove all self-energy inseration
-import ..NoHatree
+import ..NoHartree
 import ..NoFock
 import ..NoBubble  # true to remove all bubble subdiagram
 import ..Proper  #ver4, ver3, and polarization diagrams may require to be irreducible along the transfer momentum/frequency

--- a/src/diagram_tree/operation.jl
+++ b/src/diagram_tree/operation.jl
@@ -114,20 +114,20 @@ function derivative(diags::Union{Tuple,AbstractVector}, ::Type{ID}, order::Int; 
 end
 
 """
-    function removeHatreeFock!(diag::Diagram{W}) where {W}
-    function removeHatreeFock!(diags::Union{Tuple,AbstractVector})
+    function removeHartreeFock!(diag::Diagram{W}) where {W}
+    function removeHartreeFock!(diags::Union{Tuple,AbstractVector})
     
-    Remove the Hatree-Fock insertions that without any derivatives on the propagator and the interaction. 
+    Remove the Hartree-Fock insertions that without any derivatives on the propagator and the interaction. 
 
 # Arguments
 - diags      : diagrams to remove the Fock insertion
 
 # Remarks
-- The operations removeHatreeFock! and taking derivatives doesn't commute with each other! 
-- If the input diagram is a Hatree-Fock diagram, then the overall weight will become zero! 
+- The operations removeHartreeFock! and taking derivatives doesn't commute with each other! 
+- If the input diagram is a Hartree-Fock diagram, then the overall weight will become zero! 
 - The return value is always nothing
 """
-function removeHatreeFock!(diag::Diagram{W}) where {W}
+function removeHartreeFock!(diag::Diagram{W}) where {W}
     for d in PreOrderDFS(diag)
         # for subdiag in d.subdiagram
         if d.id isa SigmaId
@@ -140,8 +140,8 @@ function removeHatreeFock!(diag::Diagram{W}) where {W}
         end
     end
 end
-function removeHatreeFock!(diags::Union{Tuple,AbstractVector})
+function removeHartreeFock!(diags::Union{Tuple,AbstractVector})
     for diag in diags
-        removeHatreeFock!(diag)
+        removeHartreeFock!(diag)
     end
 end

--- a/src/expression_tree/common.jl
+++ b/src/expression_tree/common.jl
@@ -1,7 +1,7 @@
 import ..Filter
 import ..Wirreducible  #remove all polarization subdiagrams
 import ..Girreducible  #remove all self-energy inseration
-import ..NoHatree
+import ..NoHartree
 import ..NoFock
 import ..NoBubble  # true to remove all bubble subdiagram
 import ..Proper  #ver4, ver3, and polarization diagrams may require to be irreducible along the transfer momentum/frequency

--- a/src/parquet_builder/common.jl
+++ b/src/parquet_builder/common.jl
@@ -1,7 +1,7 @@
 import ..Filter
 import ..Wirreducible  #remove all polarization subdiagrams
 import ..Girreducible  #remove all self-energy inseration
-import ..NoHatree
+import ..NoHartree
 import ..NoFock
 import ..NoBubble  # true to remove all bubble subdiagram
 import ..Proper  #ver4, ver3, and polarization diagrams may require to be irreducible along the transfer momentum/frequency

--- a/src/parquet_builder/filter.jl
+++ b/src/parquet_builder/filter.jl
@@ -29,8 +29,8 @@ end
 
 # check if G exist without creating objects in the pool
 function isValidG(filter, innerLoopNum::Int)
-    #one-loop diagram could be either Fock or Hatree. If both are filtered, then nothing left
-    if ((NoFock in filter) && (NoHatree in filter)) && (innerLoopNum == 1)
+    #one-loop diagram could be either Fock or Hartree. If both are filtered, then nothing left
+    if ((NoFock in filter) && (NoHartree in filter)) && (innerLoopNum == 1)
         return false
     end
 
@@ -55,8 +55,8 @@ function isValidSigma(filter, innerLoopNum::Int, subdiagram::Bool)
         return false
     end
 
-    #one-loop diagram could be either Fock or Hatree. If both are filtered, then nothing left
-    if subdiagram && ((NoFock in filter) && (NoHatree in filter)) && innerLoopNum == 1
+    #one-loop diagram could be either Fock or Hartree. If both are filtered, then nothing left
+    if subdiagram && ((NoFock in filter) && (NoHartree in filter)) && innerLoopNum == 1
         return false
     end
 

--- a/src/parquet_builder/polarization.jl
+++ b/src/parquet_builder/polarization.jl
@@ -26,7 +26,7 @@ function polarization(para::DiagPara{W}, extK=DiagTree.getK(para.totalLoopNum, 1
     @assert length(extK) >= para.totalLoopNum "expect dim of extK>=$(para.totalLoopNum), got $(length(extK))"
 
     #polarization diagram should always proper
-    # if !(Proper in _para.filter) || (lenth(_para.transferLoop) != length(extK)) || (_para.transferLoop ≈ extK)
+    # if !(Proper in _para.filter) || (length(_para.transferLoop) != length(extK)) || (_para.transferLoop ≈ extK)
     #     # @warn "Polarization diagram parameter is not proper. It will be reconstructed with proper transfer loops."
     # para = derivepara(_para, filter=union(Proper, _para.filter), transferLoop=extK)
     # end
@@ -133,7 +133,7 @@ end
 
 function _properPolarPara(p::DiagPara{W}, q) where {W}
     # ############ reset transferLoop to be q ################
-    if !(Proper in p.filter) || (lenth(p.transferLoop) != length(extK)) || (p.transferLoop ≈ extK)
+    if !(Proper in p.filter) || (length(p.transferLoop) != length(q)) || (p.transferLoop ≈ q)
         return derivepara(p, transferLoop=q, filter=union(Proper, p.filter))
     end
     return p

--- a/src/parquet_builder/sigma.jl
+++ b/src/parquet_builder/sigma.jl
@@ -93,7 +93,7 @@ function sigma(para::DiagPara{W}, extK=DiagTree.getK(para.totalLoopNum, 1), subd
         if isValidG(paraG)
             # println(paraW)
             if oW == 0 # Fock-type Σ
-                if NoHatree in paraW.filter
+                if NoHartree in paraW.filter
                     paraW0 = reconstruct(paraW, filter=union(paraW.filter, Proper), transferLoop=zero(K))
                     ver4 = vertex4(paraW0, legK, [], true)
                 else

--- a/src/strong_coupling_expansion_builder/common.jl
+++ b/src/strong_coupling_expansion_builder/common.jl
@@ -1,7 +1,7 @@
 import ..Filter
 import ..Wirreducible  #remove all polarization subdiagrams
 import ..Girreducible  #remove all self-energy inseration
-import ..NoHatree
+import ..NoHartree
 import ..NoFock
 import ..NoBubble  # true to remove all bubble subdiagram
 import ..Proper  #ver4, ver3, and polarization diagrams may require to be irreducible along the transfer momentum/frequency

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -36,7 +36,7 @@ DiagTree.eval(id::BareInteractionId, K, extT, varT) = 8π / (K[1] * K[1] + K[2] 
 diagPara(order) = DiagParaF64(type=type, innerLoopNum=order, hasTau=true,
     interaction=[FeynmanDiagram.Interaction(ChargeCharge, Instant),],  #instant charge-charge interaction
     # filter = [NoFock,])
-    filter=[NoHatree, Girreducible,])
+    filter=[NoHartree, Girreducible,])
 
 println("Build the diagrams into an experssion tree ...")
 const para = [diagPara(o) for o in 1:Order]

--- a/test/parquet_builder.jl
+++ b/test/parquet_builder.jl
@@ -428,6 +428,9 @@ end
         return para, diag, varK, varT
     end
 
+    # Test polarization Parquet builder when filter 'Proper' is specified explicitly
+    getPolar(1, filter=[Proper, NoHartree, NoFock,])
+
     ##################  G^2*v expansion #########################################
     for l = 1:4
         para, diag, varK, varT = getPolar(l, isFermi=false, filter=[NoHartree, Girreducible,])

--- a/test/parquet_builder.jl
+++ b/test/parquet_builder.jl
@@ -44,9 +44,9 @@ end
     # for Fock irreducible diagrams, only 0-loop or 2, 3, 4...-loop G is allowed
     @test Parquet.isValidG([NoFock,], 0) == true
     @test Parquet.isValidG([NoFock,], 1) == true
-    #one-loop G diagram becomes invalid only if both Hatree and Fock are filtered
-    @test Parquet.isValidG([NoFock, NoHatree], 1) == false
-    @test Parquet.isValidG([NoFock, NoHatree], 2) == true
+    #one-loop G diagram becomes invalid only if both Hartree and Fock are filtered
+    @test Parquet.isValidG([NoFock, NoHartree], 1) == false
+    @test Parquet.isValidG([NoFock, NoHartree], 2) == true
 
     # for G irreducible diagrams, no sigma subdiagram is allowed
     @test Parquet.isValidSigma([Girreducible,], 0, true) == false
@@ -59,15 +59,15 @@ end
 
     # for Fock irreducible diagrams, no Fock sigma subdiagram is allowed
     @test Parquet.isValidSigma([NoFock,], 0, true) == false
-    #one-loop sigma diagram can be either Hatree or Fock diagram
-    #one-loop sigma sub-diagram becomes invalid only if both Hatree and Fock are filtered
+    #one-loop sigma diagram can be either Hartree or Fock diagram
+    #one-loop sigma sub-diagram becomes invalid only if both Hartree and Fock are filtered
     @test Parquet.isValidSigma([NoFock,], 1, true) == true
-    @test Parquet.isValidSigma([NoFock, NoHatree], 1, true) == false
-    @test Parquet.isValidSigma([NoFock, NoHatree], 2, true) == true
+    @test Parquet.isValidSigma([NoFock, NoHartree], 1, true) == false
+    @test Parquet.isValidSigma([NoFock, NoHartree], 2, true) == true
 
     @test Parquet.isValidSigma([NoFock,], 0, false) == false
     @test Parquet.isValidSigma([NoFock,], 1, false) == true
-    @test Parquet.isValidSigma([NoFock, NoHatree], 1, false) == true
+    @test Parquet.isValidSigma([NoFock, NoHartree], 1, false) == true
     @test Parquet.isValidSigma([NoFock,], 2, false) == true
 end
 
@@ -113,7 +113,7 @@ evalFakePropagator(id::PropagatorId, K, extT, varT) = 1.0
         end
     end
 
-    function testVertex4(loopNum, chan, type::Symbol; filter=[NoHatree,], timing=false, toeval=true)
+    function testVertex4(loopNum, chan, type::Symbol; filter=[NoHartree,], timing=false, toeval=true)
         println("$(Int.(chan)) Channel Test")
         Kdim, spin = 3, 2
         interactionTauNum = 1
@@ -244,7 +244,7 @@ evalFakePropagator(id::PropagatorId, K, extT, varT) = 1.0
 end
 
 @testset "Parquet Sigma" begin
-    function getSigma(loopNum; Kdim=3, spin=2, interactionTauNum=1, filter=[NoHatree,], isFermi=true, subdiagram=false)
+    function getSigma(loopNum; Kdim=3, spin=2, interactionTauNum=1, filter=[NoHartree,], isFermi=true, subdiagram=false)
         println("LoopNum =$loopNum Sigma Test")
 
         para = DiagParaF64(
@@ -293,7 +293,7 @@ end
     for l = 1:4
         # ret = getSigma(l, spin = 1, isFermi = false, filter = [Builder.Girreducible,])
         # testDiagramNumber(ret...)
-        ret = getSigma(l, spin=2, isFermi=false, filter=[NoHatree, Girreducible,])
+        ret = getSigma(l, spin=2, isFermi=false, filter=[NoHartree, Girreducible,])
         testDiagramNumber(ret...)
     end
 
@@ -303,7 +303,7 @@ end
 end
 
 @testset "Green" begin
-    function buildG(loopNum, extT; Kdim=3, spin=2, interactionTauNum=1, filter=[NoHatree,], isFermi=true)
+    function buildG(loopNum, extT; Kdim=3, spin=2, interactionTauNum=1, filter=[NoHartree,], isFermi=true)
         para = DiagParaF64(
             type=GreenDiag,
             loopDim=Kdim,
@@ -327,26 +327,26 @@ end
     # DiagTree.showTree(diag, Gidx)
 
     # If G is irreducible, then only loop-0 G exist for main diagram, and no G exist for subdiagram
-    G = buildG(0, [1, 2]; filter=[NoHatree, Girreducible,])
+    G = buildG(0, [1, 2]; filter=[NoHartree, Girreducible,])
     @test G isa Diagram
-    G = buildG(1, [1, 2]; filter=[NoHatree, Girreducible,])
+    G = buildG(1, [1, 2]; filter=[NoHartree, Girreducible,])
     @test isnothing(G)
-    G = buildG(2, [1, 2]; filter=[NoHatree, Girreducible,])
+    G = buildG(2, [1, 2]; filter=[NoHartree, Girreducible,])
     @test isnothing(G)
 
     # If Fock diagram is not allowed, then one-loop G diagram should not be exist for subdiagram
-    G = buildG(0, [1, 2]; filter=[NoHatree, NoFock,])
+    G = buildG(0, [1, 2]; filter=[NoHartree, NoFock,])
     @test G isa Diagram
-    G = buildG(1, [1, 2]; filter=[NoHatree, NoFock,])
+    G = buildG(1, [1, 2]; filter=[NoHartree, NoFock,])
     @test isnothing(G)
-    G = buildG(2, [1, 2]; filter=[NoHatree, NoFock,]) #high order subdiagram is allowed
+    G = buildG(2, [1, 2]; filter=[NoHartree, NoFock,]) #high order subdiagram is allowed
     @test G isa Diagram
 
 end
 
 
 @testset "Parquet Vertex3" begin
-    function getGamma3(loopNum; Kdim=3, spin=2, interactionTauNum=1, filter=[NoHatree, Girreducible, Proper,], isFermi=true, subdiagram=false)
+    function getGamma3(loopNum; Kdim=3, spin=2, interactionTauNum=1, filter=[NoHartree, Girreducible, Proper,], isFermi=true, subdiagram=false)
         println("LoopNum =$loopNum Vertex3 Test")
 
         para = DiagParaF64(
@@ -392,7 +392,7 @@ end
     for l = 1:3
         # ret = getSigma(l, spin = 1, isFermi = false, filter = [Builder.Girreducible,])
         # testDiagramNumber(ret...)
-        ret = getGamma3(l, isFermi=false, filter=[NoHatree, Girreducible, Proper])
+        ret = getGamma3(l, isFermi=false, filter=[NoHartree, Girreducible, Proper])
         testDiagramNumber(ret...)
     end
 
@@ -403,7 +403,7 @@ end
 
 
 @testset "Parquet Polarization" begin
-    function getPolar(loopNum; Kdim=3, spin=2, interactionTauNum=1, filter=[NoHatree, Girreducible,], isFermi=true, subdiagram=false)
+    function getPolar(loopNum; Kdim=3, spin=2, interactionTauNum=1, filter=[NoHartree, Girreducible,], isFermi=true, subdiagram=false)
         println("LoopNum =$loopNum Polarization Test")
 
         para = DiagParaF64(
@@ -430,7 +430,7 @@ end
 
     ##################  G^2*v expansion #########################################
     for l = 1:4
-        para, diag, varK, varT = getPolar(l, isFermi=false, filter=[NoHatree, Girreducible,])
+        para, diag, varK, varT = getPolar(l, isFermi=false, filter=[NoHartree, Girreducible,])
         diag = mergeby(diag).diagram[1]
         w = DiagTree.evalKT!(diag, varK, varT; eval=evalFakePropagator)
         # factor = (1 / (2π)^para.loopDim)^para.innerLoopNum
@@ -442,7 +442,7 @@ end
 
     ##################  g^2*v expansion #########################################
     for l = 1:4
-        para, diag, varK, varT = getPolar(l, isFermi=false, filter=[NoHatree, NoFock,])
+        para, diag, varK, varT = getPolar(l, isFermi=false, filter=[NoHartree, NoFock,])
         diag = mergeby(diag).diagram[1]
         w = DiagTree.evalKT!(diag, varK, varT, eval=evalFakePropagator)
         # factor = (1 / (2π)^para.loopDim)^para.innerLoopNum
@@ -454,7 +454,7 @@ end
 
     ##################  g^2*v expansion for the upup polarization #########################################
     for l = 1:4
-        para, diag, varK, varT = getPolar(l, isFermi=false, filter=[NoHatree, NoFock,])
+        para, diag, varK, varT = getPolar(l, isFermi=false, filter=[NoHartree, NoFock,])
         w = DiagTree.evalKT!(diag.diagram[1], varK, varT, eval=evalFakePropagator)
         # factor = (1 / (2π)^para.loopDim)^para.innerLoopNum
         factor = 1.0


### PR DESCRIPTION
1. Fix typos ('Hatree' -> 'Hartree').
2. Bugfix in function `_properPolarPara`: the test set "Parquet Polarization" in master branch fails upon adding the line `getPolar(1, filter=[Proper, NoHatree, NoFock,])`.
3. Update test set "Parquet Polarization" to check behavior when filter 'Proper' is specified explicitly.