### PR TITLE
Allow user-specified name to persist in Parquet.green

### DIFF
--- a/src/parquet_builder/green.jl
+++ b/src/parquet_builder/green.jl
@@ -99,6 +99,17 @@ function green(para::DiagPara{W}, extK=DiagTree.getK(para.totalLoopNum, 1), extT
     # println(ΣGpairs)
     # println(operator)
     ΣGmerged = mergeby(ΣGpairs; operator=Sum(), name=:gΣG)[1]
-    compositeG = Diagram{W}(GreenId(para, k=extK, t=extT), Prod(), [g0, ΣGmerged], name=:G)
+
+    # ORIGINAL:
+    # compositeG = Diagram{W}(GreenId(para, k=extK, t=extT), Prod(), [g0, ΣGmerged], name=:G)
+
+    # PROPOSITION 1: Allow the user's custom name to persist after unwrapping with Parquet.green
+    compositeG = Diagram{W}(GreenId(para, k=extK, t=extT), Prod(), [g0, ΣGmerged], name=name)
+
+    # PROPOSITION 2: Allow the user's custom name to persist after unwrapping with Parquet.green
+    #                if the string representation contains "G" (e.g., :G₁ and :Gdashed are allowed)
+    # validname = contains(string(name), "G") ? name : (:G)
+    # compositeG = Diagram{W}(GreenId(para, k=extK, t=extT), Prod(), [g0, ΣGmerged], name=validname)
+
     return compositeG
 end


### PR DESCRIPTION
If the user specifies a high-order Green's function label, e.g., `name = :G₁`, this should persist after the expansion in `Parquet.green`. Currently, the name field will be replaced by `:G` when `innerLoopNum > 0`. I propose one of the following:

1. Allow any user-specified name to persist after building with Parquet.green: 
```julia
compositeG = Diagram{W}(GreenId(para, k=extK, t=extT), Prod(), [g0, ΣGmerged], name=name)
```
2. The same, but enforce some constraints (e.g., name contains "G") and revert to default behavior if unmet:
```julia
validname = contains(string(name), "G") ? name : (:G)
compositeG = Diagram{W}(GreenId(para, k=extK, t=extT), Prod(), [g0, ΣGmerged], name=validname)
```