### PR TITLE
Refactor contractions to edge list conversion

### DIFF
--- a/src/FeynmanDiagram.jl
+++ b/src/FeynmanDiagram.jl
@@ -85,6 +85,7 @@ export DiagramPara, DiagramParaF64
 include("computational_graph/ComputationalGraph.jl")
 using .ComputationalGraphs
 export ComputationalGraphs
+export labelreset, parity, parity_old
 export QuantumOperator, CompositeOperator
 export 𝑓⁻, 𝑓⁺, 𝑓, 𝑏⁻, 𝑏⁺, 𝜙
 export fermionic_annihilation, fermionic_creation, majorana

--- a/src/FeynmanDiagram.jl
+++ b/src/FeynmanDiagram.jl
@@ -85,23 +85,22 @@ export DiagramPara, DiagramParaF64
 include("computational_graph/ComputationalGraph.jl")
 using .ComputationalGraphs
 export ComputationalGraphs
+export QuantumOperator, CompositeOperator
+export 𝑓⁻, 𝑓⁺, 𝑓, 𝑏⁻, 𝑏⁺, 𝜙
+export fermionic_annihilation, fermionic_creation, majorana
+export bosonic_annihilation, bosonic_creation, real_scalar
+export ExternalVertex, InternalVertex, Graph
+export feynman_diagram, contractions_to_edges, propagator
+# export reducibility, connectivity
+# export 𝐺ᶠ, 𝐺ᵇ, 𝐺ᵠ, 𝑊, Green2, Interaction
+# export Coupling_yukawa, Coupling_phi3, Coupling_phi4, Coupling_phi6
+
 # export TwoBodyChannel, Alli, PHr, PHEr, PPr, AnyChan
 # export Permutation, Di, Ex, DiEx
-export Graph, ExternalVertex, InternalVertex
 # export OneFermiIrreducible, OneBoseIrreducible, ParticleHoleIrreducible, ParticleParticleIrreducible
-export reducibility, connectivity
 # export addSubDiagram!, evalDiagNode!, evalDiagTree!, evalDiagTreeKT!
 # export Operator, Sum, Prod
 # export uidreset, toDataFrame, mergeby, plot_tree
-# export 𝐺ᶠ, 𝐺ᵇ, 𝐺ᵠ, 𝑊, Green2, Interaction
-export QuantumOperator, CompositeOperator
-# export 𝑓, 𝑓dag, γ, 𝑏, 𝑏dag, ϕ
-export 𝑓⁻, 𝑓⁺, 𝑓, 𝑏⁻, 𝑏⁺, 𝜙
-export fermionic_annihilation, fermionic_creation, majorana
-export bosonic_annihilation, bosonic_creation, real_classic
-export feynman_diagram, contractions_to_edges, propagator, labelreset
-# export Coupling_yukawa, Coupling_phi3, Coupling_phi4, Coupling_phi6
-
 
 include("diagram_tree/DiagTree.jl")
 using .DiagTree

--- a/src/computational_graph/ComputationalGraph.jl
+++ b/src/computational_graph/ComputationalGraph.jl
@@ -17,26 +17,29 @@ Base.length(r::Permutation) = 1
 Base.iterate(r::Permutation) = (r, nothing)
 function Base.iterate(r::Permutation, ::Permutation) end
 
-include("common.jl")
-include("graph.jl")
-# include("tree.jl")
-# include("operation.jl")
-include("io.jl")
-# include("eval.jl")
-# include("optimize.jl")
-
 const INL, OUTL, INR, OUTR = 1, 2, 3, 4
 
-export Graph
-export ExternalVertex, InternalVertex
-export labelreset
-export fermionic_annihilation, fermionic_creation, majorana
-export bosonic_annihilation, bosonic_creation, real_scalar
-# export 𝐺ᶠ, 𝐺ᵇ, 𝐺ᵠ, 𝑊, Green2, Interaction
+include("common.jl")
+export labelreset, parity, parity_old
+
+include("graph.jl")
 export QuantumOperator, CompositeOperator
 export 𝑓⁻, 𝑓⁺, 𝑓, 𝑏⁻, 𝑏⁺, 𝜙
-export feynman_diagram, contractions_to_edges, propagator, labelreset
+export fermionic_annihilation, fermionic_creation, majorana
+export bosonic_annihilation, bosonic_creation, real_scalar
+export ExternalVertex, InternalVertex, Graph
+export feynman_diagram, contractions_to_edges, propagator
+# export 𝐺ᶠ, 𝐺ᵇ, 𝐺ᵠ, 𝑊, Green2, Interaction
 # export Coupling_yukawa, Coupling_phi3, Coupling_phi4, Coupling_phi6
+
+# include("tree.jl")
+# include("operation.jl")
+
+include("io.jl")
+# plot_tree
+
+# include("eval.jl")
+# include("optimize.jl")
 
 # export addSubDiagram!
 # export evalDiagTree!

--- a/src/computational_graph/common.jl
+++ b/src/computational_graph/common.jl
@@ -88,3 +88,54 @@ function getK(loopNum::Int, loopIdx::Int)
     return k
 end
 
+"""
+The parity of a permutation P of length n is even if P has an even number of even-length cycles, 
+and odd otherwise, where a cycle's parity is -1 if it is even in length. 
+
+The total parity of P is then given by: sgn(P) = (-1)^(n - n_cycles)
+"""
+function parity(p::W) where {W<:AbstractVector{Int}}
+    n = length(p)
+    visited = Set{Int}()
+    unvisited = Set{Int}(1:n)
+    # Continue searching until we visit every item
+    n_cycles = 0
+    while isempty(unvisited) == false
+        cycle = Int[]
+        x = pop!(unvisited)
+        # Continue until we complete the cycle
+        while in(x, visited) == false
+            push!(cycle, x)
+            push!(visited, x)
+            x = p[x]
+            pop!(unvisited, x, 0)
+        end
+        # Found a cycle
+        n_cycles += 1
+    end
+    return (-1)^(n - n_cycles)
+end
+
+"""
+calculate the parity of a given permutation of the array [1, 2, 3, ...]
+"""
+function parity_old(p)
+    n = length(p)
+    not_seen = Set{Int}(1:n)
+    seen = Set{Int}()
+    cycles = Array{Int,1}[]
+    while !isempty(not_seen)
+        cycle = Int[]
+        x = pop!(not_seen)
+        while !in(x, seen)
+            push!(cycle, x)
+            push!(seen, x)
+            x = p[x]
+            pop!(not_seen, x, 0)
+        end
+        push!(cycles, cycle)
+    end
+    cycle_lengths = map(length, cycles)
+    even_cycles = filter(i -> i % 2 == 0, cycle_lengths)
+    length(even_cycles) % 2 == 0 ? 1 : -1
+end

--- a/src/computational_graph/common.jl
+++ b/src/computational_graph/common.jl
@@ -89,31 +89,20 @@ function getK(loopNum::Int, loopIdx::Int)
 end
 
 """
-The parity of a permutation P of length n is even if P has an even number of even-length cycles, 
-and odd otherwise, where a cycle's parity is -1 if it is even in length. 
-
-The total parity of P is then given by: sgn(P) = (-1)^(n - n_cycles)
+The parity of a permutation P is +1 if the number of 2-cycles (swaps) in an n-cycle
+decomposition with n ≤ 2 is even, and -1 if the number of 2-cycles is odd.
 """
 function parity(p::W) where {W<:AbstractVector{Int}}
-    n = length(p)
-    visited = Set{Int}()
-    unvisited = Set{Int}(1:n)
-    # Continue searching until we visit every item
-    n_cycles = 0
-    while isempty(unvisited) == false
-        cycle = Int[]
-        x = pop!(unvisited)
-        # Continue until we complete the cycle
-        while in(x, visited) == false
-            push!(cycle, x)
-            push!(visited, x)
-            x = p[x]
-            pop!(unvisited, x, 0)
+    count = 0
+    p_swap = copy(p)
+    for i in eachindex(p)
+        while p_swap[i] != i
+            count += 1
+            j = p_swap[i]  # NOTE: we cannot swap in place with nested access in Julia
+            p_swap[i], p_swap[j] = p_swap[j], p_swap[i]
         end
-        # Found a cycle
-        n_cycles += 1
     end
-    return (-1)^(n - n_cycles)
+    return 2 * iseven(count) - 1
 end
 
 """

--- a/src/computational_graph/graph.jl
+++ b/src/computational_graph/graph.jl
@@ -323,7 +323,6 @@ function contractions_to_edges(vertices::Vector{CompositeOperator}; contractions
         )
     end
     # Loop over operators and pair
-    sign = 1
     next_pairing = 1
     edges = Vector{EdgeType}()
     for (i, wick_i) in enumerate(contractions)
@@ -339,8 +338,6 @@ function contractions_to_edges(vertices::Vector{CompositeOperator}; contractions
                 @debug "Found Wick contraction #$wick_i, adding edge between operators $i and $j"
                 if operators[j].operator == :f⁺
                     push!(edges, (j, i))
-                    # Extra minus sign when a Fermionic contraction is out of order
-                    sign *= -1
                 elseif operators[j].operator == :b⁺
                     push!(edges, (j, i))
                 else
@@ -351,7 +348,8 @@ function contractions_to_edges(vertices::Vector{CompositeOperator}; contractions
             end
         end
     end
-    # TODO: Deduce the remaining statistical sign associated with this normal-ordered contraction.
+    # TODO: Deduce the parity of the contraction
+    sign = 1
     return edges, sign
 end
 

--- a/src/computational_graph/graph.jl
+++ b/src/computational_graph/graph.jl
@@ -81,6 +81,10 @@ const 𝑏⁻ = bosonic_annihilation
 const 𝑏⁺ = bosonic_creation
 const 𝜙 = real_classic
 
+function isfermionic(operator::QuantumOperator)
+    operator.operator in [:f⁺, :f⁻, :f]
+end
+
 struct CompositeOperator <: AbstractVector{QuantumOperator}
     operators::Vector{QuantumOperator}
     function CompositeOperator(operators::Vector{QuantumOperator})
@@ -348,8 +352,22 @@ function contractions_to_edges(vertices::Vector{CompositeOperator}; contractions
             end
         end
     end
-    # TODO: Deduce the parity of the contraction
-    sign = 1
+    # Deduce the parity of the contraction; it is the
+    # same as the parity of all fermionic operators.
+    flat_fermionic_edges = Int[]
+    for (e1, e2) in edges
+        op1, op2 = operators[e1], operators[e2]
+        if isfermionic(op1) || isfermionic(op2)
+            append!(flat_fermionic_edges, [e1, e2])
+        end
+    end
+    if isempty(flat_fermionic_edges)
+        sign = 1
+    else
+        # Get the permutation parity for the flattened list of fermionic edges, e.g.,
+        # flat_fermionic_edges = [1, 5, 4, 8, 7, 6] => P = (1 3 2 6 5 4) => sign = +1
+        sign = parity(sortperm(flat_fermionic_edges))
+    end
     return edges, sign
 end
 

--- a/test/ComputationalGraph.jl
+++ b/test/ComputationalGraph.jl
@@ -43,31 +43,43 @@
 
 @testset "Contractions" begin
     # Test 1: Scalar fields with Wick crossings, sign = +1
-    op1 = CompositeOperator([𝜙(1), 𝜙(1), 𝜙(1), 𝜙(1), 𝜙(1), 𝜙(1), 𝜙(1), 𝜙(1)])
-    edges1, sign1 = contractions_to_edges(op1, [1, 2, 3, 4, 1, 3, 4, 2])
+    vertices1 = [
+        CompositeOperator([𝜙(1), 𝜙(2)]),
+        CompositeOperator([𝜙(3), 𝜙(4), 𝜙(5), 𝜙(6)]),
+        CompositeOperator([𝜙(7), 𝜙(8)]),
+    ]
+    edges1, sign1 = contractions_to_edges(vertices1; contractions=[1, 2, 3, 4, 1, 3, 4, 2])
     @test Set(edges1) == Set([(1, 5), (2, 8), (3, 6), (4, 7)])
     @test sign1 == 1
 
-    # Test 2: Identical bosons with Wick crossings, sign = +1
-    op2 = CompositeOperator([𝑏⁺(1), 𝑏⁺(1), 𝑏⁺(1), 𝑏⁺(1), 𝑏⁻(1), 𝑏⁻(1), 𝑏⁻(1), 𝑏⁻(1)])
-    edges2, sign2 = contractions_to_edges(op2, [1, 2, 3, 4, 3, 1, 4, 2])
+    # Test 2: Bosons with Wick crossings, sign = +1
+    vertices2 = [
+        CompositeOperator([𝑏⁺(1), 𝑏⁺(2), 𝑏⁺(3)]),
+        CompositeOperator([𝑏⁺(4), 𝑏⁻(5)]),
+        CompositeOperator([𝑏⁻(6), 𝑏⁻(7), 𝑏⁻(8)]),
+    ]
+    edges2, sign2 = contractions_to_edges(vertices2; contractions=[1, 2, 3, 4, 3, 1, 4, 2])
     @test Set(edges2) == Set([(1, 6), (2, 8), (3, 5), (4, 7)])
     @test sign2 == 1
 
-    # Test 3: Majoranas with no Wick crossings, sign = +1
-    op3 = CompositeOperator([𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1)])
-    edges3, sign3 = contractions_to_edges(op3, [1, 2, 3, 4, 4, 3, 2, 1])
+    # Test 3: Indistinguishable Majoranas with no Wick crossings, sign = +1
+    vertices3 = [CompositeOperator([𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1)])]
+    edges3, sign3 = contractions_to_edges(vertices3; contractions=[1, 2, 3, 4, 4, 3, 2, 1])
     @test Set(edges3) == Set([(1, 8), (2, 7), (3, 6), (4, 5)])
     @test sign3 == 1
 
-    # Test 4: Identical fermions with no Wick crossings, sign = +1
-    op4 = CompositeOperator([𝑓⁺(1), 𝑓⁺(1), 𝑓⁺(1), 𝑓⁺(1), 𝑓⁻(1), 𝑓⁻(1), 𝑓⁻(1), 𝑓⁻(1)])
-    edges4, sign4 = contractions_to_edges(op4, [1, 2, 3, 4, 4, 3, 2, 1])
-    @test Set(edges4) == Set([(1, 8), (2, 7), (3, 6), (4, 5)])
-    @test sign4 == 1
+    # Test 4: Fermions with Wick crossings. sign = +1 from Fermion
+    #         contraction orderings (times additional statistical sign TBD).
+    vertices4 = [
+        CompositeOperator([𝑓⁺(1), 𝑓⁻(2)]),
+        CompositeOperator([𝑓⁺(5), 𝑓⁺(6), 𝑓⁻(7), 𝑓⁻(8)]),
+        CompositeOperator([𝑓⁺(3), 𝑓⁻(4)]),
+    ]
+    edges4, sign4 = contractions_to_edges(vertices4; contractions=[1, 2, 2, 3, 1, 4, 4, 3])
+    @test Set(edges4) == Set([(1, 5), (3, 2), (4, 8), (7, 6)])
+    @test sign4 == 1  # TODO: implement remaining statistical sign
 
-    # TODO: Implement statistical sign for general CompositeOperator, and the following tests:
-    #       Test 5: Fermions with Wick crossings, sign = -1
-    #       Test 6: Mixed bosonic/fermionic CompositeOperator with different labels
-    #       ...
+    # TODO: Implement statistical sign and the following tests:
+    #       - Test overall sign for fermions with Wick crossings s.t. sign = -1
+    #       - Test overall sign for mixed bosonic/fermionic operators and different labels
 end

--- a/test/ComputationalGraph.jl
+++ b/test/ComputationalGraph.jl
@@ -1,5 +1,3 @@
-# using .FeynmanDiagram.ComputationalGraphs  # using Compo
-
 # @testset "Diagram" begin
 #     # electron gas
 #     g1 = 𝐺ᶠ(1, 2) * 𝑊(1, 2) * 𝐺ᶠ(2, 1)          # vaccum diagram
@@ -41,45 +39,76 @@
 #     @test checkVertices(g5)
 # end
 
+@testset "Parity" begin
+    # P = (1) => sgn(P) = 1
+    p1 = [1]
+    @test parity(p1) == 1
+    @test parity_old(p1) == 1
+
+    # P = (2 3 1 5 6 4) = (1 2 3) (4 5 6) => sgn(P) = 1
+    p2 = [2, 3, 1, 5, 6, 4]
+    @test parity(p2) == 1
+    @test parity_old(p2) == 1
+
+    # P = (3 4 1 2) = (1 3) (2 4) => sgn(P) = 1
+    p3 = [3, 4, 1, 2]
+    @test parity(p3) == 1
+    @test parity_old(p3) == 1
+
+    # P = (3 5 1 2 4 6 7) = (1 3) (2 5 4) (6) (7) => sgn(P) = -1
+    p4 = [3, 5, 1, 2, 4, 6, 7]
+    @test parity(p4) == -1
+    @test parity_old(p4) == -1
+end
+
 @testset "Contractions" begin
-    # Test 1: Scalar fields with Wick crossings, sign = +1
+    # Test 1: Scalar fields with Wick crossings, parity = +1
     vertices1 = [
         CompositeOperator([𝜙(1), 𝜙(2)]),
         CompositeOperator([𝜙(3), 𝜙(4), 𝜙(5), 𝜙(6)]),
         CompositeOperator([𝜙(7), 𝜙(8)]),
     ]
-    edges1, sign1 = contractions_to_edges(vertices1; contractions=[1, 2, 3, 4, 1, 3, 4, 2])
+    edges1, parity1 = contractions_to_edges(vertices1; contractions=[1, 2, 3, 4, 1, 3, 4, 2])
     @test Set(edges1) == Set([(1, 5), (2, 8), (3, 6), (4, 7)])
-    # @test sign1 == __  # TODO
+    @test parity1 == 1
 
-    # Test 2: Bosons with Wick crossings, sign = +1
+    # Test 2: Bosons with Wick crossings, parity = +1
     vertices2 = [
         CompositeOperator([𝑏⁺(1), 𝑏⁺(2), 𝑏⁻(3)]),
         CompositeOperator([𝑏⁻(4), 𝑏⁺(5)]),
         CompositeOperator([𝑏⁻(6), 𝑏⁺(7), 𝑏⁻(8)]),
     ]
-    edges2, sign2 = contractions_to_edges(vertices2; contractions=[1, 2, 3, 4, 3, 1, 4, 2])
+    edges2, parity2 = contractions_to_edges(vertices2; contractions=[1, 2, 3, 4, 3, 1, 4, 2])
     @test Set(edges2) == Set([(1, 6), (2, 8), (5, 3), (7, 4)])
-    # @test sign2 == __  # TODO
+    @test parity2 == 1
 
-    # Test 3: Indistinguishable Majoranas with no Wick crossings, sign = +1
+    # Test 3: Indistinguishable Majoranas with no Wick crossings, parity = +1
     vertices3 = [CompositeOperator([𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1)])]
-    edges3, sign3 = contractions_to_edges(vertices3; contractions=[1, 2, 3, 4, 4, 3, 2, 1])
+    edges3, parity3 = contractions_to_edges(vertices3; contractions=[1, 2, 3, 4, 4, 3, 2, 1])
     @test Set(edges3) == Set([(1, 8), (2, 7), (3, 6), (4, 5)])
-    # @test sign3 == __  # TODO
+    # P = (1 8 2 7 3 6 4 5) = (1)(5 3 2 8)(4 7)(6) => parity = +1
+    @test parity3 == 1
 
-    # Test 4: Fermions with Wick crossings. sign = +1 from Fermion
-    #         contraction orderings (times additional statistical sign TBD).
+    # Test 4: Fermions with Wick crossings, parity = -1
     vertices4 = [
         CompositeOperator([𝑓⁺(1), 𝑓⁻(2)]),
         CompositeOperator([𝑓⁺(5), 𝑓⁺(6), 𝑓⁻(7), 𝑓⁻(8)]),
         CompositeOperator([𝑓⁺(3), 𝑓⁻(4)]),
     ]
-    edges4, sign4 = contractions_to_edges(vertices4; contractions=[1, 2, 2, 3, 1, 4, 4, 3])
+    edges4, parity4 = contractions_to_edges(vertices4; contractions=[1, 2, 2, 3, 1, 4, 4, 3])
     @test Set(edges4) == Set([(1, 5), (3, 2), (4, 8), (7, 6)])
-    # @test sign4 == __  # TODO
+    # P = (1 5 3 2 4 8 7 6) = (1)(2 5 4)(3)(6 8)(7) => parity = -1
+    @test parity4 == -1
 
-    # TODO: Implement statistical sign and the following tests:
-    #       - Test overall sign for fermions with Wick crossings s.t. sign = -1
-    #       - Test overall sign for mixed bosonic/fermionic operators and different labels
+    # Test 5: Mixed bosonic/classical/fermionic operators, parity = -1
+    vertices5 = [
+        CompositeOperator([𝑏⁺(1), 𝑓⁺(2), 𝜙(3)]),
+        CompositeOperator([𝑓⁻(4), 𝑓⁻(5)]),
+        CompositeOperator([𝑏⁻(6), 𝑓⁺(7), 𝜙(8)]),
+    ]
+    edges5, parity5 = contractions_to_edges(vertices5; contractions=[1, 2, 3, 2, 4, 1, 4, 3])
+    @test Set(edges5) == Set([(1, 6), (2, 4), (3, 8), (7, 5)])
+    # Flattened fermionic edges: [2, 4, 7, 5]
+    # => P = (1 2 4 3) = (1)(2)(4 3) => parity = -1
+    @test parity5 == -1
 end

--- a/test/ComputationalGraph.jl
+++ b/test/ComputationalGraph.jl
@@ -50,7 +50,7 @@
     ]
     edges1, sign1 = contractions_to_edges(vertices1; contractions=[1, 2, 3, 4, 1, 3, 4, 2])
     @test Set(edges1) == Set([(1, 5), (2, 8), (3, 6), (4, 7)])
-    @test sign1 == 1
+    # @test sign1 == __  # TODO
 
     # Test 2: Bosons with Wick crossings, sign = +1
     vertices2 = [
@@ -60,13 +60,13 @@
     ]
     edges2, sign2 = contractions_to_edges(vertices2; contractions=[1, 2, 3, 4, 3, 1, 4, 2])
     @test Set(edges2) == Set([(1, 6), (2, 8), (5, 3), (7, 4)])
-    @test sign2 == 1
+    # @test sign2 == __  # TODO
 
     # Test 3: Indistinguishable Majoranas with no Wick crossings, sign = +1
     vertices3 = [CompositeOperator([𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1), 𝑓(1)])]
     edges3, sign3 = contractions_to_edges(vertices3; contractions=[1, 2, 3, 4, 4, 3, 2, 1])
     @test Set(edges3) == Set([(1, 8), (2, 7), (3, 6), (4, 5)])
-    @test sign3 == 1
+    # @test sign3 == __  # TODO
 
     # Test 4: Fermions with Wick crossings. sign = +1 from Fermion
     #         contraction orderings (times additional statistical sign TBD).
@@ -77,7 +77,7 @@
     ]
     edges4, sign4 = contractions_to_edges(vertices4; contractions=[1, 2, 2, 3, 1, 4, 4, 3])
     @test Set(edges4) == Set([(1, 5), (3, 2), (4, 8), (7, 6)])
-    @test sign4 == 1  # TODO: implement remaining statistical sign
+    # @test sign4 == __  # TODO
 
     # TODO: Implement statistical sign and the following tests:
     #       - Test overall sign for fermions with Wick crossings s.t. sign = -1

--- a/test/ComputationalGraph.jl
+++ b/test/ComputationalGraph.jl
@@ -54,12 +54,12 @@
 
     # Test 2: Bosons with Wick crossings, sign = +1
     vertices2 = [
-        CompositeOperator([𝑏⁺(1), 𝑏⁺(2), 𝑏⁺(3)]),
-        CompositeOperator([𝑏⁺(4), 𝑏⁻(5)]),
-        CompositeOperator([𝑏⁻(6), 𝑏⁻(7), 𝑏⁻(8)]),
+        CompositeOperator([𝑏⁺(1), 𝑏⁺(2), 𝑏⁻(3)]),
+        CompositeOperator([𝑏⁻(4), 𝑏⁺(5)]),
+        CompositeOperator([𝑏⁻(6), 𝑏⁺(7), 𝑏⁻(8)]),
     ]
     edges2, sign2 = contractions_to_edges(vertices2; contractions=[1, 2, 3, 4, 3, 1, 4, 2])
-    @test Set(edges2) == Set([(1, 6), (2, 8), (3, 5), (4, 7)])
+    @test Set(edges2) == Set([(1, 6), (2, 8), (5, 3), (7, 4)])
     @test sign2 == 1
 
     # Test 3: Indistinguishable Majoranas with no Wick crossings, sign = +1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,10 +9,10 @@ using AbstractTrees
 # end
 if isempty(ARGS)
     include("common.jl")
+    include("ComputationalGraph.jl")
     include("diagram_tree.jl")
     include("expression_tree.jl")
     include("parquet_builder.jl")
-    include("ComputationalGraph.jl")
 else
     include(ARGS[1])
 end


### PR DESCRIPTION
1. Remove normal-ordering assumption from function `contractions_to_edges` and update test set "Contractions"
2. Deduce parity of contractions in `contractions_to_edges` and add tests for parity
3. Add functions `parity` to common.jl and `isfermionic` to graph.jl
4. Organize exports