### PR TITLE
Bugfix

### DIFF
--- a/src/computational_graph/graph.jl
+++ b/src/computational_graph/graph.jl
@@ -114,6 +114,7 @@ function isequiv(a::Graph, b::Graph, args...)
         if field == :weight
             (getproperty(a, :weight) ≈ getproperty(b, :weight)) == false && return false
         elseif field == :subgraphs
+            length(a.subgraphs) != length(b.subgraphs) && return false
             !all(isequiv.(getproperty(a, field), getproperty(b, field), args...)) && return false
         else
             getproperty(a, field) != getproperty(b, field) && return false

--- a/test/computational_graph.jl
+++ b/test/computational_graph.jl
@@ -2,6 +2,17 @@
     V = [𝑓⁺(1)𝑓⁻(2), 𝑓⁺(5)𝑓⁺(6)𝑓⁻(7)𝑓⁻(8), 𝑓⁺(3)𝑓⁻(4)]
     g1 = Graph(V, external=[1, 3])
     g2 = g1 * 2
+    @testset "Equivalence" begin
+        g1p = Graph(V, external=[1, 3])
+        g2 = Graph(V, external=[1, 3], factor=2)
+        @test isequiv(g1, g1p) == false
+        @test isequiv(g1, g2, :id) == false
+        @test isequiv(g1, g2, :factor) == false
+        @test isequiv(g1, g1p, :id)
+        @test isequiv(g1, g2, :id, :factor)
+        # Test equivalence when subgraph lengths are different
+        
+    end
     @testset "Scalar multiplication" begin
         @test vertices(g2) == vertices(g1)
         println(external(g2))

--- a/test/computational_graph.jl
+++ b/test/computational_graph.jl
@@ -2,16 +2,18 @@
     V = [𝑓⁺(1)𝑓⁻(2), 𝑓⁺(5)𝑓⁺(6)𝑓⁻(7)𝑓⁻(8), 𝑓⁺(3)𝑓⁻(4)]
     g1 = Graph(V, external=[1, 3])
     g2 = g1 * 2
-    @testset "Equivalence" begin
+    @testset "Graph equivalence" begin
         g1p = Graph(V, external=[1, 3])
-        g2 = Graph(V, external=[1, 3], factor=2)
+        g2p = Graph(V, external=[1, 3], factor=2)
+        # Test equivalence modulo fields id/factor
         @test isequiv(g1, g1p) == false
-        @test isequiv(g1, g2, :id) == false
-        @test isequiv(g1, g2, :factor) == false
+        @test isequiv(g1, g2p, :id) == false
+        @test isequiv(g1, g2p, :factor) == false
         @test isequiv(g1, g1p, :id)
-        @test isequiv(g1, g2, :id, :factor)
-        # Test equivalence when subgraph lengths are different
-        
+        @test isequiv(g1, g2p, :id, :factor)
+        # Test inequivalence when subgraph lengths are different
+        t = g1 + g1
+        @test isequiv(t, g1, :id) == false
     end
     @testset "Scalar multiplication" begin
         @test vertices(g2) == vertices(g1)


### PR DESCRIPTION
1. Fix a bug in `isequiv` where comparison of graphs with unequal number of subgraphs would throw an error instead of returning false, e.g., `g = propagator([𝑓⁺(1), 𝑓⁻(2)]); h = g + g; isequiv(g, h, :id)`.
2. Add tests for graph (in)equivalence modulo fields and subgraph number.