### PR TITLE
Bugfix

### DIFF
--- a/src/FeynmanDiagram.jl
+++ b/src/FeynmanDiagram.jl
@@ -105,7 +105,7 @@ export labelreset, parity
 # export AbstractOperator, Prod, Sum
 
 export AbstractGraph, AbstractOperator
-export Graph, FeynmanGraph, FeynmanProperties, BuiltinGraphType
+export Graph, FeynmanGraph, FeynmanProperties
 
 export isequiv, drop_topology, is_external, is_internal, diagram_type, orders, vertices, topology
 export external_legs, external_indices, external_operators, external_labels

--- a/src/computational_graph/ComputationalGraph.jl
+++ b/src/computational_graph/ComputationalGraph.jl
@@ -22,8 +22,7 @@ export unary_istrivial, isassociative, isequiv
 include("graph.jl")
 include("feynmangraph.jl")
 
-const BuiltinGraphType = Union{Graph,FeynmanGraph}
-export Graph, FeynmanGraph, FeynmanProperties, BuiltinGraphType
+export Graph, FeynmanGraph, FeynmanProperties
 # export DiagramType
 
 export isequiv, drop_topology, is_external, is_internal, diagram_type, orders, vertices, topology

--- a/src/computational_graph/feynmangraph.jl
+++ b/src/computational_graph/feynmangraph.jl
@@ -499,7 +499,7 @@ function external_vertex(ops::OperatorProduct;
 end
 
 """
-    function group(gv::Vector{G}, indices::Vector{Int}) where {G<:FeynmanGraph}
+    function group(gv::AbstractVector{G}, indices::Vector{Int}) where {G<:FeynmanGraph}
 
 Group the graphs in `gv` by the external operators at the indices `indices`. Return a dictionary of `Vector{OperatorProduct}` to `GraphVector`.
 
@@ -531,7 +531,7 @@ Dict{Vector{OperatorProduct}, Vector{FeynmanGraph{Float64, Float64}}} with 2 ent
   [f⁺(1)] => [1:f⁺(1)|f⁻(2)⋅-1.0=0.0, 2:f⁺(1)|f⁻(3)⋅-1.0=0.0]
 ```
 """
-function group(gv::Vector{G}, indices::Vector{Int}) where {G<:FeynmanGraph}
+function group(gv::AbstractVector{G}, indices::Vector{Int}) where {G<:FeynmanGraph}
     l = length(external_indices(gv[1]))
     @assert all(x -> length(external_indices(x)) == l, gv)
     groups = Dict{Vector{OperatorProduct},Vector{G}}()

--- a/src/computational_graph/io.jl
+++ b/src/computational_graph/io.jl
@@ -42,12 +42,6 @@ end
     To add support for a user-defined graph type `G`, provide an overload method `Base.show(io::IO, graph::G; kwargs...)` with a custom text representation.
 """
 function Base.show(io::IO, graph::G; kwargs...) where {G<:AbstractGraph}
-    if graph isa BuiltinGraphType == false
-        error(
-            "No built-in string representation for user-defined graph type $G. " *
-            "Please provide an overload method 'Base.show(io::IO, graph::G; kwargs...)' with a custom text representation."
-        )
-    end
     if length(graph.subgraphs) == 0
         typestr = ""
     else
@@ -77,7 +71,7 @@ function plot_tree(graph::AbstractGraph; verbose=0, maxdepth=6)
         if level > maxdepth
             return
         end
-        name = graph isa BuiltinGraphType ? "$(_stringrep(node, false))" : "$node"
+        name = "$(_stringrep(node, false))"
         nt = t.add_child(name=name)
 
         if length(node.subgraphs) > 0

--- a/src/frontend/GV_diagrams/readfile.jl
+++ b/src/frontend/GV_diagrams/readfile.jl
@@ -26,10 +26,10 @@ function _exchange(perm::Vector{Int}, ver4Legs::Vector{Vector{Int}}, index::Int,
     end
     return permu_ex, ver4Legs_ex
 end
-
-function _group(gv::AbstractVector{FeynmanGraph}, indices::Vector{Vector{Int}})
-    l = length(external_indices(gv[1]))
-    @assert all(x -> length(external_indices(x)) == l, gv)
+ 
+function _group(gv::AbstractVector{G}, indices::Vector{Vector{Int}}) where {G<:FeynmanGraph} 
+    l = length(IR.external_indices(gv[1]))
+    @assert all(x -> length(IR.external_indices(x)) == l, gv)
     @assert length(gv) == length(indices)
     groups = Dict{Vector{Int},Vector{G}}()
     for (i, t) in enumerate(gv)


### PR DESCRIPTION
1. Remove BuiltinGraphType, cleanup I/O
2. Bugfix in functions `group` and `_group` for GV

TODO: `removeDuplicatedLeaves!` currently throws an error for `ElectronLiquid.Sigma.MC` with `diagtype=:GV`.