### PR TITLE
Computgraph daniel

### DIFF
--- a/src/backend/static.jl
+++ b/src/backend/static.jl
@@ -31,12 +31,12 @@ function _to_static(::Type{ComputationalGraphs.Prod}, subgraphs::Vector{FeynmanG
 end
 
 """
-    function to_julia_str(graphs::AbstractVector{G}; root::AbstractVector{Int}=[g.id for g in graphs], name::String="eval_graph!") where {G<:AbstractGraph}
+    function to_julia_str(graphs::AbstractVector{<:AbstractGraph}; root::AbstractVector{Int}=[g.id for g in graphs], name::String="eval_graph!")
     
 Compile a list of graphs into a string for a julia static function. The function takes two arguments: `root` and `leaf`. 
 `root` is a vector of the root node ids of the graphs, and `leaf` is a vector of the leaf nodes' weights of the graphs. 
 """
-function to_julia_str(graphs::AbstractVector{G}; root::AbstractVector{Int}=[g.id for g in graphs], name::String="eval_graph!") where {G<:AbstractGraph}
+function to_julia_str(graphs::AbstractVector{<:AbstractGraph}; root::AbstractVector{Int}=[g.id for g in graphs], name::String="eval_graph!")
     head = "function $name(root::AbstractVector, leaf::AbstractVector)\n "
     body = ""
     leafidx = 1
@@ -60,8 +60,8 @@ function to_julia_str(graphs::AbstractVector{G}; root::AbstractVector{Int}=[g.id
 end
 
 """
-    function to_julia_str(graphs::AbstractVector{G}, leafMap::Dict{Int,Int}; root::AbstractVector{Int}=[g.id for g in graphs],
-        name::String="eval_graph!") where {G<:AbstractGraph}
+    function to_julia_str(graphs::AbstractVector{<:AbstractGraph}, leafMap::Dict{Int,Int}; root::AbstractVector{Int}=[g.id for g in graphs],
+        name::String="eval_graph!")
     
 Compile a list of Feynman graphs into a string for a julia static function. The complied function takes two arguments: `root` and `leafVal`. 
 `root` is a vector of the root node ids of the graphs, and `leafVal` is a vector of the leaf nodes' weights of the graphs. 
@@ -72,8 +72,8 @@ Compile a list of Feynman graphs into a string for a julia static function. The 
 - `root` (AbstractVector{Int}, optional): The vector of the root node ids of the graphs (defaults to `[g.id for g in graphs]`).
 - `name` (String,optional): The name of the complied function (defaults to `"eval_graph!"`).  
 """
-function to_julia_str(graphs::AbstractVector{G}, leafMap::Dict{Int,Int}; root::AbstractVector{Int}=[g.id for g in graphs],
-    name::String="eval_graph!") where {G<:AbstractGraph}
+function to_julia_str(graphs::AbstractVector{<:AbstractGraph}, leafMap::Dict{Int,Int}; root::AbstractVector{Int}=[g.id for g in graphs],
+    name::String="eval_graph!")
     head = "function $name(root::AbstractVector, leafVal::AbstractVector)\n "
     body = ""
     for graph in graphs
@@ -97,7 +97,7 @@ function to_julia_str(graphs::AbstractVector{G}, leafMap::Dict{Int,Int}; root::A
 end
 
 """
-    function compile(graphs::AbstractVector{G}; root::AbstractVector{Int}=[g.id for g in graphs]) where {G<:AbstractGraph}
+    function compile(graphs::AbstractVector{<:AbstractGraph}; root::AbstractVector{Int}=[g.id for g in graphs])
     
 Compile a list of graphs into a julia static function. 
 The function takes two arguments: `root` and `leaf`. `root` is a vector of the root node ids of the graphs, and `leaf` is a vector of the leaf node ids of the graphs. 
@@ -118,16 +118,16 @@ leaf = [1.0, 2.0]
 @assert eval_graph!(root, leaf) ≈ (leaf[1] + leaf[2]) * factor
 ```
 """
-function compile(graphs::AbstractVector{G};
-    root::AbstractVector{Int}=[g.id for g in graphs]) where {G<:AbstractGraph}
+function compile(graphs::AbstractVector{<:AbstractGraph};
+    root::AbstractVector{Int}=[g.id for g in graphs])
     # this function return a runtime generated function defined by compile()
     func_string = to_julia_str(graphs; root=root, name="func_name!")
     func_expr = Meta.parse(func_string)
     return @RuntimeGeneratedFunction(func_expr)
 end
 
-function compile(graphs::AbstractVector{G}, leafMap::Dict{Int,Int};
-    root::AbstractVector{Int}=[g.id for g in graphs]) where {G<:AbstractGraph}
+function compile(graphs::AbstractVector{<:AbstractGraph}, leafMap::Dict{Int,Int};
+    root::AbstractVector{Int}=[g.id for g in graphs])
     # this function return a runtime generated function defined by compile()
     func_string = to_julia_str(graphs, leafMap; root=root, name="func_name!")
     func_expr = Meta.parse(func_string)

--- a/src/computational_graph/abstractgraph.jl
+++ b/src/computational_graph/abstractgraph.jl
@@ -14,11 +14,11 @@ Base.show(io::IO, ::Type{Prod}) = print(io, "Ⓧ")
 # Is the unary form of operator 𝓞 trivial: 𝓞(G) ≡ G?
 # NOTE: this property implies that 𝓞(c * G) = c * G = c * 𝓞(G), so
 #       we may propagate the subgraph factor c up to the parent graph.
-unary_istrivial(::Type{O}) where {O<:AbstractOperator} = false
-unary_istrivial(::Type{O}) where {O<:Union{Sum,Prod}} = true  # (+g) ≡ g and (*g) ≡ g
+unary_istrivial(::Type{<:AbstractOperator}) = false
+unary_istrivial(::Type{<:Union{Sum,Prod}}) = true  # (+g) ≡ g and (*g) ≡ g
 
 # Is the operation associative: a 𝓞 (b 𝓞 c) = (a 𝓞 b) 𝓞 c = a 𝓞 b 𝓞 c?
-isassociative(::Type{O}) where {O<:AbstractOperator} = false
+isassociative(::Type{<:AbstractOperator}) = false
 isassociative(::Type{Sum}) = true
 # NOTE: Associativity of Prod (graph composition)
 #       requires Base.*(g1, g2) and Base./(g1, g2)

--- a/src/computational_graph/io.jl
+++ b/src/computational_graph/io.jl
@@ -17,6 +17,15 @@ function short(factor, ignore=nothing)
     end
 end
 
+function short_orders(orders)
+    orders_no_trailing_zeros = ""
+    idx_last_set = findlast(x -> x != 0, orders)
+    if isnothing(idx_last_set) == false
+        orders_no_trailing_zeros *= string(orders[1:idx_last_set])
+    end
+    return orders_no_trailing_zeros
+end
+
 function _stringrep(graph::AbstractGraph, color=true)
     namestr = isempty(graph.name) ? "" : "-$(graph.name)"
     idstr = "$(graph.id)$namestr"
@@ -25,7 +34,7 @@ function _stringrep(graph::AbstractGraph, color=true)
     end
     fstr = short(graph.factor, one(graph.factor))
     wstr = short(graph.weight)
-    ostr = string(orders(graph))
+    ostr = short_orders(orders(graph))
     # =$(node.weight*(2π)^(3*node.id.para.innerLoopNum))
 
     if length(graph.subgraphs) == 0

--- a/src/computational_graph/io.jl
+++ b/src/computational_graph/io.jl
@@ -17,7 +17,7 @@ function short(factor, ignore=nothing)
     end
 end
 
-function _stringrep(graph::G, color=true) where {G<:AbstractGraph}
+function _stringrep(graph::AbstractGraph, color=true)
     namestr = isempty(graph.name) ? "" : "-$(graph.name)"
     idstr = "$(graph.id)$namestr"
     if graph isa FeynmanGraph
@@ -25,23 +25,22 @@ function _stringrep(graph::G, color=true) where {G<:AbstractGraph}
     end
     fstr = short(graph.factor, one(graph.factor))
     wstr = short(graph.weight)
+    ostr = string(orders(graph))
     # =$(node.weight*(2π)^(3*node.id.para.innerLoopNum))
 
     if length(graph.subgraphs) == 0
-        return isempty(fstr) ? "$idstr=$wstr" : "$(idstr)⋅$(fstr)=$wstr"
+        return isempty(fstr) ? "$(idstr)$(ostr)=$wstr" : "$(idstr)⋅$(fstr)=$wstr"
     else
-        return "$idstr=$wstr=$(fstr)$(graph.operator) "
+        return "$(idstr)$(ostr)=$wstr=$(fstr)$(graph.operator) "
     end
 end
 
 """
-    show(io::IO, graph::G; kwargs...) where {G<:AbstractGraph}
+    show(io::IO, graph::AbstractGraph; kwargs...)
 
-    Write a text representation of `graph` to the output stream `io`.
-
-    To add support for a user-defined graph type `G`, provide an overload method `Base.show(io::IO, graph::G; kwargs...)` with a custom text representation.
+    Write a text representation of an AbstractGraph `graph` to the output stream `io`.
 """
-function Base.show(io::IO, graph::G; kwargs...) where {G<:AbstractGraph}
+function Base.show(io::IO, graph::AbstractGraph; kwargs...)
     if length(graph.subgraphs) == 0
         typestr = ""
     else
@@ -50,7 +49,7 @@ function Base.show(io::IO, graph::G; kwargs...) where {G<:AbstractGraph}
     end
     print(io, "$(_stringrep(graph, true))$typestr")
 end
-Base.show(io::IO, ::MIME"text/plain", graph::G; kwargs...) where {G<:AbstractGraph} = Base.show(io, graph; kwargs...)
+Base.show(io::IO, ::MIME"text/plain", graph::AbstractGraph; kwargs...) = Base.show(io, graph; kwargs...)
 
 """
     function plot_tree(graph::AbstractGraph; verbose = 0, maxdepth = 6)
@@ -107,7 +106,7 @@ function plot_tree(graph::AbstractGraph; verbose=0, maxdepth=6)
     # t.write(outfile="/home/kun/test.txt", format=8)
     t.show(tree_style=ts)
 end
-function plot_tree(graphs::Vector{G}; kwargs...) where {G<:AbstractGraph}
+function plot_tree(graphs::Vector{<:AbstractGraph}; kwargs...)
     for graph in graphs
         plot_tree(graph; kwargs...)
     end

--- a/src/computational_graph/optimize.jl
+++ b/src/computational_graph/optimize.jl
@@ -1,4 +1,4 @@
-function optimize!(graphs::Union{Tuple,AbstractVector{G}}; verbose=0, normalize=nothing) where {G<:AbstractGraph}
+function optimize!(graphs::Union{Tuple,AbstractVector{<:AbstractGraph}}; verbose=0, normalize=nothing)
     if isempty(graphs)
         return nothing
     else
@@ -10,13 +10,13 @@ function optimize!(graphs::Union{Tuple,AbstractVector{G}}; verbose=0, normalize=
     end
 end
 
-function optimize(graphs::Union{Tuple,AbstractVector{G}}; verbose=0, normalize=nothing) where {G<:AbstractGraph}
+function optimize(graphs::Union{Tuple,AbstractVector{<:AbstractGraph}}; verbose=0, normalize=nothing)
     graphs_new = deepcopy(graphs)
     leaf_mapping = optimize!(graphs_new)
     return graphs_new, leaf_mapping
 end
 
-function merge_all_chain_prefactors!(g::G; verbose=0) where {G<:AbstractGraph}
+function merge_all_chain_prefactors!(g::AbstractGraph; verbose=0)
     verbose > 0 && println("merge prefactors of all nodes representing trivial unary chains toward root level.")
     # Post-order DFS
     for sub_g in g.subgraphs
@@ -27,7 +27,7 @@ function merge_all_chain_prefactors!(g::G; verbose=0) where {G<:AbstractGraph}
     return g
 end
 
-function merge_all_chain_prefactors!(graphs::AbstractVector{G}; verbose=0) where {G<:AbstractGraph}
+function merge_all_chain_prefactors!(graphs::AbstractVector{<:AbstractGraph}; verbose=0)
     verbose > 0 && println("merge prefactors of all nodes representing trivial unary chains toward root level.")
     # Post-order DFS
     for g in graphs
@@ -37,7 +37,7 @@ function merge_all_chain_prefactors!(graphs::AbstractVector{G}; verbose=0) where
     return graphs
 end
 
-function merge_all_factorless_chains!(g::G; verbose=0) where {G<:AbstractGraph}
+function merge_all_factorless_chains!(g::AbstractGraph; verbose=0)
     verbose > 0 && println("merge all nodes representing factorless trivial unary chains.")
     # Post-order DFS
     for sub_g in g.subgraphs
@@ -48,7 +48,7 @@ function merge_all_factorless_chains!(g::G; verbose=0) where {G<:AbstractGraph}
     return g
 end
 
-function merge_all_factorless_chains!(graphs::AbstractVector{G}; verbose=0) where {G<:AbstractGraph}
+function merge_all_factorless_chains!(graphs::AbstractVector{<:AbstractGraph}; verbose=0)
     verbose > 0 && println("merge all nodes representing factorless trivial unary chains.")
     # Post-order DFS
     for g in graphs
@@ -58,21 +58,21 @@ function merge_all_factorless_chains!(graphs::AbstractVector{G}; verbose=0) wher
     return graphs
 end
 
-function merge_all_chains!(g::G; verbose=0) where {G<:AbstractGraph}
+function merge_all_chains!(g::AbstractGraph; verbose=0)
     verbose > 0 && println("merge all nodes representing trivial unary chains.")
     merge_all_chain_prefactors!(g, verbose=verbose)
     merge_all_factorless_chains!(g, verbose=verbose)
     return g
 end
 
-function merge_all_chains!(graphs::AbstractVector{G}; verbose=0) where {G<:AbstractGraph}
+function merge_all_chains!(graphs::AbstractVector{<:AbstractGraph}; verbose=0)
     verbose > 0 && println("merge all nodes representing trivial unary chains.")
     merge_all_chain_prefactors!(graphs, verbose=verbose)
     merge_all_factorless_chains!(graphs, verbose=verbose)
     return graphs
 end
 
-function merge_all_linear_combinations!(g::G; verbose=0) where {G<:AbstractGraph}
+function merge_all_linear_combinations!(g::AbstractGraph; verbose=0)
     verbose > 0 && println("merge nodes representing a linear combination of a non-unique list of graphs.")
     # Post-order DFS
     for sub_g in g.subgraphs
@@ -83,7 +83,7 @@ function merge_all_linear_combinations!(g::G; verbose=0) where {G<:AbstractGraph
     return g
 end
 
-function merge_all_linear_combinations!(graphs::AbstractVector{G}; verbose=0) where {G<:AbstractGraph}
+function merge_all_linear_combinations!(graphs::AbstractVector{<:AbstractGraph}; verbose=0)
     verbose > 0 && println("merge nodes representing a linear combination of a non-unique list of graphs.")
     # Post-order DFS
     for g in graphs
@@ -93,7 +93,7 @@ function merge_all_linear_combinations!(graphs::AbstractVector{G}; verbose=0) wh
     return graphs
 end
 
-function unique_leaves(_graphs::AbstractVector{G}) where {G<:AbstractGraph}
+function unique_leaves(_graphs::AbstractVector{<:AbstractGraph})
     ############### find the unique Leaves #####################
     uniqueGraph = []
     mapping = Dict{Int,Int}()
@@ -117,9 +117,9 @@ function unique_leaves(_graphs::AbstractVector{G}) where {G<:AbstractGraph}
     return uniqueGraph, mapping
 end
 
-function remove_duplicated_leaves!(graphs::AbstractVector{G}; verbose=0, normalize=nothing, kwargs...) where {G<:AbstractGraph}
+function remove_duplicated_leaves!(graphs::AbstractVector{<:AbstractGraph}; verbose=0, normalize=nothing, kwargs...)
     verbose > 0 && println("remove duplicated leaves.")
-    leaves = Vector{G}()
+    leaves = Vector{eltype(graphs)}()
     for g in graphs
         append!(leaves, collect(Leaves(g)))
     end

--- a/src/quantum_operator/expression.jl
+++ b/src/quantum_operator/expression.jl
@@ -190,7 +190,7 @@ end
 The parity of a permutation P is +1 if the number of 2-cycles (swaps) in an n-cycle
 decomposition with n ≤ 2 is even, and -1 if the number of 2-cycles is odd.
 """
-function parity(p::W) where {W<:AbstractVector{Int}}
+function parity(p::AbstractVector{Int})
     count = 0
     p_swap = copy(p)
     for i in eachindex(p)

--- a/test/computational_graph.jl
+++ b/test/computational_graph.jl
@@ -278,7 +278,6 @@ end
             @test external_legs(g1) == [false, false, true, true]
             parameters = FeynmanProperties(
                 diagram_type(g1),
-                orders(g1),
                 vertices(g1),
                 topology(g1),
                 external_indices(g1),
@@ -286,7 +285,6 @@ end
             )
             parameters_no_topology = FeynmanProperties(
                 diagram_type(g1),
-                orders(g1),
                 vertices(g1),
                 [],
                 external_indices(g1),


### PR DESCRIPTION
1. Add back field `orders` to graph, move `orders` from `FeynmanProperties` to field in `FeynmanGraph`.
2. Add `orders(g::Graph)` and `orders(g::FeynmanGraph)` helper functions.
3. Remove unnecessary parametric types (use idiom `v::AbstractVector{<:AbstractT}` instead of `v::AbstractVector{T} ... where {T<:AbstractT}`).