### PR TITLE
Improve graph I/O

### DIFF
--- a/src/computational_graph/ComputationalGraph.jl
+++ b/src/computational_graph/ComputationalGraph.jl
@@ -37,12 +37,12 @@ export multi_product, linear_combination, feynman_diagram, propagator, interacti
 # export 𝐺ᶠ, 𝐺ᵇ, 𝐺ᵠ, 𝑊, Green2, Interaction
 
 
-include("tree_properties.jl")
-export haschildren, onechild, isleaf, isbranch, ischain, has_zero_subfactors, eldest, count_operation
-
 include("operation.jl")
 include("io.jl")
 export plot_tree
+
+include("tree_properties.jl")
+export haschildren, onechild, isleaf, isbranch, ischain, has_zero_subfactors, eldest, count_operation
 
 include("eval.jl")
 export eval!

--- a/src/computational_graph/abstractgraph.jl
+++ b/src/computational_graph/abstractgraph.jl
@@ -16,9 +16,15 @@ Base.isequal(a::AbstractOperator, b::AbstractOperator) = (typeof(a) == typeof(b)
 Base.:(==)(a::AbstractOperator, b::AbstractOperator) = Base.isequal(a, b)
 apply(o::AbstractOperator, diags) = error("not implemented!")
 
+Base.print(io::IO, o::AbstractOperator) = print(io, typeof(o))
+Base.print(io::IO, ::Type{Sum}) = print(io, "Sum")
+Base.print(io::IO, ::Type{Prod}) = print(io, "Prod")
+Base.print(io::IO, ::Type{Unitary}) = print(io, "Unitary")
+Base.print(io::IO, ::Type{Power{N}}) where {N} = print(io, "Power{$N}")
+
 Base.show(io::IO, o::AbstractOperator) = print(io, typeof(o))
 Base.show(io::IO, ::Type{Sum}) = print(io, "⨁")
-Base.show(io::IO, ::Type{Prod}) = print(io, "Ⓧ")
+Base.show(io::IO, ::Type{Prod}) = print(io, "Ⓧ ")
 Base.show(io::IO, ::Type{Unitary}) = print(io, "𝟙")
 Base.show(io::IO, ::Type{Power{N}}) where {N} = print(io, "^$N")
 

--- a/src/computational_graph/abstractgraph.jl
+++ b/src/computational_graph/abstractgraph.jl
@@ -90,6 +90,13 @@ function operator(g::AbstractGraph) end
 function weight(g::AbstractGraph) end
 
 """
+    function properties(g::AbstractGraph)
+
+    Returns additional properties, if any, of the computational graph `g`.
+"""
+function properties(g::AbstractGraph) end
+
+"""
 function subgraph(g::AbstractGraph, i=1)
     
     Returns a copy of the `i`th subgraph of computational graph `g`.
@@ -183,6 +190,13 @@ function set_weight!(g::AbstractGraph, weight)
     Update the weight of graph `g` to `weight`.
 """
 function set_weight!(g::AbstractGraph, weight) end
+
+"""
+function set_properties!(g::AbstractGraph, properties)
+
+    Update the properties of graph `g` to `properties`.
+"""
+function set_properties!(g::AbstractGraph, properties) end
 
 """
 function set_subgraph!(g::AbstractGraph, subgraph::AbstractGraph, i=1)

--- a/src/computational_graph/tree_properties.jl
+++ b/src/computational_graph/tree_properties.jl
@@ -1,7 +1,7 @@
 ##################### AbstractTrees interface for AbstractGraphs ########################### 
 
 ## Things that make printing prettier
-AbstractTrees.printnode(io::IO, g::AbstractGraph) = print(io, "\u001b[32m$(id(g))\u001b[0m : $g")
+AbstractTrees.printnode(io::IO, g::AbstractGraph) = print(io, _stringrep(g; color=true))
 
 ## Guarantee type-stable tree iteration for Graphs and FeynmanGraphs
 AbstractTrees.NodeType(::Graph) = HasNodeType()

--- a/src/computational_graph/tree_properties.jl
+++ b/src/computational_graph/tree_properties.jl
@@ -80,30 +80,12 @@ function ischain(g::AbstractGraph)
     return false
 end
 
-# """
-#     function isfactorless(g)
-
-#     Returns whether the graph g is factorless, i.e., has unity factor and, if applicable,
-#     subgraph factor(s). Note that this function does not recurse through subgraphs of g, so 
-#     that one may have, e.g., `isfactorless(g) == true` but `isfactorless(eldest(g)) == false`.
-
-# # Arguments:
-# - `g::AbstractGraph`: graph to be analyzed
-# """
-# function isfactorless(g::AbstractGraph)
-#     if isleaf(g)
-#         return isapprox_one(factor(g))
-#     else
-#         return all(isapprox_one.([factor(g); subgraph_factors(g)]))
-#     end
-# end
-
 """
     function has_zero_subfactors(g)
 
     Returns whether the graph g has only zero-valued subgraph factor(s). 
     Note that this function does not recurse through subgraphs of g, so that one may have, e.g.,
-    `isfactorless(g) == true` but `isfactorless(eldest(g)) == false`.
+    `has_zero_subfactors(g) == true` but `has_zero_subfactors(eldest(g)) == false`.
     By convention, returns `false` if g is a leaf.
 
 # Arguments:

--- a/src/quantum_operator/expression.jl
+++ b/src/quantum_operator/expression.jl
@@ -64,7 +64,8 @@ Base.setindex!(o::OperatorProduct, v::QuantumOperator, i::Int) = o.operators[i] 
 Base.length(o::OperatorProduct) = length(o.operators)
 Base.size(o::OperatorProduct) = size(o.operators)
 
-Base.show(io::IO, o::OperatorProduct) = print(io, reduce(*, ["$o" for o in o.operators]))
+Base.print(io::IO, o::OperatorProduct) = print(io, reduce(*, [string(o) for o in o.operators]))
+Base.show(io::IO, o::OperatorProduct) = print(io, reduce(*, [repr(o) for o in o.operators]))
 Base.show(io::IO, ::MIME"text/plain", o::OperatorProduct) = Base.show(io, o)
 
 """

--- a/src/quantum_operator/operator.jl
+++ b/src/quantum_operator/operator.jl
@@ -13,6 +13,14 @@ struct BosonCreation <: AbstractQuantumOperator end
 struct BosonAnnihilation <: AbstractQuantumOperator end
 struct Classic <: AbstractQuantumOperator end
 
+Base.print(io::IO, o::AbstractQuantumOperator) = print(io, typeof(o))
+Base.print(io::IO, ::Type{FermiCreation}) = print(io, "FermiCreation")
+Base.print(io::IO, ::Type{FermiAnnihilation}) = print(io, "FermiAnnihilation")
+Base.print(io::IO, ::Type{Majorana}) = print(io, "Majorana")
+Base.print(io::IO, ::Type{BosonCreation}) = print(io, "BosonCreation")
+Base.print(io::IO, ::Type{BosonAnnihilation}) = print(io, "BosonAnnihilation")
+Base.print(io::IO, ::Type{Classic}) = print(io, "Classic")
+
 Base.show(io::IO, ::Type{FermiCreation}) = print(io, "f⁺")
 Base.show(io::IO, ::Type{FermiAnnihilation}) = print(io, "f⁻")
 Base.show(io::IO, ::Type{Majorana}) = print(io, "f")
@@ -65,7 +73,8 @@ Base.:(==)(a::QuantumOperator, b::QuantumOperator) = Base.isequal(a, b)
 # Relabel constructor
 QuantumOperator(qo::QuantumOperator, label::Int) = QuantumOperator(qo.operator(), label)
 
-Base.show(io::IO, o::QuantumOperator) = print(io, "$(o.operator)($(o.label))")
+Base.print(io::IO, o::QuantumOperator) = print(io, "$(o.operator)($(o.label))")
+Base.show(io::IO, o::QuantumOperator) = print(io, "$(repr(o.operator))($(o.label))")
 Base.show(io::IO, ::MIME"text/plain", o::QuantumOperator) = Base.show(io, o)
 
 """

--- a/test/computational_graph.jl
+++ b/test/computational_graph.jl
@@ -164,8 +164,6 @@ end
             g3 = g1 + g2
             @test g3.subgraphs == [g1]
             @test g3.subgraph_factors == [3]
-            # @test g3.subgraphs == [g1, g1]
-            # @test g3.subgraph_factors == [1, 2]
             @test g3.operator == Graphs.Sum
         end
         @testset "Subtraction" begin
@@ -173,8 +171,6 @@ end
             @test g4.subgraphs == [g1]
             @test g4.subgraph_factors == [-1]
             @test g4.subgraphs[1] == g1
-            # @test g4.subgraphs == [g1, g1]
-            # @test g4.subgraph_factors == [1, -2]
             @test g4.operator == Graphs.Sum
         end
         @testset "Linear combinations" begin
@@ -184,15 +180,11 @@ end
             g5lc = linear_combination(g1, g2, 3, 5)
             @test g5lc.subgraphs == [g1,]
             @test g5lc.subgraph_factors == [13,]
-            # @test g5lc.subgraphs == [g1, g1]
-            # @test g5lc.subgraph_factors == [3, 10]
             @test isequiv(g5, g5lc, :id)
             # Vector form
             g6lc = linear_combination([g1, g2, g5, g2, g1], [3, 5, 7, 9, 11])
             @test g6lc.subgraphs == [g1]
             @test g6lc.subgraph_factors == [133]  # 3+5*2+7*13+9*2+11 
-            # @test g6lc.subgraphs == [g1, g1, g5, g1, g1]
-            # @test g6lc.subgraph_factors == [3, 10, 7, 18, 11]
             # Test one-level merging of multiplicative chains
             g7lc = g1 + 2 * (3 * g1 + 5 * g2p)
             g7lc_expect = g1 + 2 * linear_combination([g1, g2p], [3, 5])
@@ -240,12 +232,11 @@ end
         g1 = Graph([])
         g2 = Graph([g1,]; subgraph_factors=[5,], operator=Graphs.Prod())
         g3 = Graph([g2,]; subgraph_factors=[3,], operator=Graphs.Prod())
-        # g = 2*(3*(5*g1))
+        # g: 2*(3*(5*g1))
         g = Graph([g3,]; subgraph_factors=[2,], operator=Graphs.Prod())
-        # gp = 2*(3*(g1 + 5*g1))
-        # g2p = g1 + g2
         g2p = Graph([g1, g2]; operator=Graphs.Sum())
         g3p = Graph([g2p,]; subgraph_factors=[3,], operator=Graphs.Prod())
+        # gp: 2*(3*(g1 + 5*g1))
         gp = Graph([g3p,]; subgraph_factors=[2,], operator=Graphs.Prod())
         @testset "Merge prefactors" begin
             g1 = propagator(𝑓⁺(1)𝑓⁻(2))
@@ -264,7 +255,6 @@ end
             g1s = propagator(𝑓⁺(1)𝑓⁻(2), factor=-1)
             @test isequiv(h3, FeynmanGraph([g1s, g1s], drop_topology(g1.properties); subgraph_factors=[-1, -4]), :id)
             h4 = merge_linear_combination(h3)
-            # @test isequiv(h3, h4, :id)
             @test isequiv(h4, FeynmanGraph([g1s], drop_topology(g1.properties); subgraph_factors=[-5]), :id)
 
             h5 = FeynmanGraph([g1, g2, g2, g1], drop_topology(g1.properties); subgraph_factors=[3, 5, 7, 9], operator=Graphs.Sum())
@@ -273,12 +263,10 @@ end
             @test length(h6.subgraphs) == 2
             @test h6.subgraphs == [g1, g2]
             @test h6.subgraph_factors == [12, 12]
-            # @test isequiv(h5_lc, h6, :id)
             @test isequiv(h5_lc, FeynmanGraph([g1s, g1s], drop_topology(g1.properties); subgraph_factors=[-12, -24]), :id)
             @test isequiv(h6, FeynmanGraph([g1, g2], drop_topology(g1.properties); subgraph_factors=[12, 12]), :id)
 
             g3 = 2 * g1
-            # h7 = FeynmanGraph([g1, g3, g3, g1]; subgraph_factors=[3, 5, 7, 9], operator=Graphs.Sum())
             h7 = FeynmanGraph([g1, g1, g1, g1], drop_topology(g1.properties); subgraph_factors=[3, 5 * 2, 7 * 2, 9], operator=Graphs.Sum())
             h7_lc = linear_combination([g1, g3, g3, g1], [3, 5, 7, 9])
             h8 = merge_linear_combination(h7)
@@ -554,8 +542,6 @@ end
             @test external_operators(g3) == external_operators(g1)
             @test g3.subgraphs == [g1]
             @test g3.subgraph_factors == [3]
-            # @test g3.subgraphs == [g1, g1]
-            # @test g3.subgraph_factors == [1, 2]
             @test g3.operator == Graphs.Sum
         end
         @testset "Subtraction" begin
@@ -564,8 +550,6 @@ end
             @test external_operators(g4) == external_operators(g1)
             @test g4.subgraphs == [g1,]
             @test g4.subgraph_factors == [-1,]
-            # @test g4.subgraphs == [g1, g1]
-            # @test g4.subgraph_factors == [1, -2]
             @test g4.operator == Graphs.Sum
         end
         @testset "Linear combinations" begin
@@ -575,15 +559,11 @@ end
             g5lc = linear_combination(g1, g2, 3, 5)
             @test g5lc.subgraphs == [g1,]
             @test g5lc.subgraph_factors == [13,]
-            # @test g5lc.subgraphs == [g1, g1]
-            # @test g5lc.subgraph_factors == [3, 10]
             @test isequiv(g5, g5lc, :id)
             # Vector form
             g6lc = linear_combination([g1, g2, g5, g2, g1], [3, 5, 7, 9, 11])
             @test g6lc.subgraphs == [g1,]
             @test g6lc.subgraph_factors == [133]
-            # @test g6lc.subgraphs == [g1, g1, g5, g1, g1]
-            # @test g6lc.subgraph_factors == [3, 10, 7, 18, 11]
             # Test one-level merging of multiplicative chains
             g7lc = g1 + 2 * (3 * g1 + 5 * g2p)
             g7lc_expect = g1 + 2 * linear_combination([g1, g2p], [3, 5])
@@ -639,7 +619,6 @@ end
             @test isequiv(gsum.subgraphs[1], gsum.subgraphs[2])
             gnew = replace_subgraph(groot, g2, g3)
             @test isequiv(gnew, g1 + FeynmanGraph([g3, g3], drop_topology(g3.properties)), :id)
-            # @test isequiv(gnew, g1 + (g3 + g3), :id)
         end
         @testset "Prune trivial unary operations" begin
             g1 = propagator(𝑓⁺(1)𝑓⁻(2))
@@ -670,13 +649,11 @@ end
             h0 = FeynmanGraph([g1, g4, g5], subgraph_factors=[2, -1, 1])
             h1 = FeynmanGraph([h0], operator=Graphs.Prod(), subgraph_factors=[2])
             h = FeynmanGraph([h1, g5])
-            # _h = FeynmanGraph([FeynmanGraph([g1, g5], subgraph_factors=[-28, 1]), g5], subgraph_factors=[2, 1])
             g1p = eldest(g5)
             _h = FeynmanGraph([FeynmanGraph([g1, g1p], subgraph_factors=[-28, 3]), g1p], subgraph_factors=[2, 3])
 
             hvec_op = Graphs.optimize(repeat([deepcopy(h)], 3))
             @test all(isequiv(h, _h, :id) for h in hvec_op)
-            # @test Graphs.eval!(hvec_op[1], leafMap, leaf) ≈ Graphs.eval!(h, leafMap, leaf)
             @test Graphs.eval!(hvec_op[1], randseed=1) ≈ Graphs.eval!(_h, randseed=1)
 
             Graphs.optimize!([h])
@@ -886,7 +863,6 @@ end
     G4 = 4 * g1 * g1
     G5 = 4 * (2 * G3 + 3 * G4)
     G6 = (2 * g1 + 3 * g2) * (4 * g1 + g3) * g1
-    #G6 = (g1 + g2) * (g1 + g2) * g1
     G7 = (3 * g1 + 4 * g2 + 5 * g3) * 3 * g1
 
     @testset "node_derivative" begin
@@ -913,11 +889,8 @@ end
         for (i, G) in enumerate([G3, G4, G5, G6, G7])
             back_deriv = backAD(G)
             for (id_pair, value_back) in back_deriv
-                # gs = Compilers.to_julia_str([value,], name="eval_graph!")
-                # println("id:$(key)", gs, "\n")
                 value_forward = forwardAD(G, id_pair[2])
                 @test eval!(value_back) == eval!(value_forward)
-                # print("value:$(i+2) $(eval!(value_forward))\n")
             end
         end
     end
@@ -1093,8 +1066,6 @@ end
         @test isleaf(g1)
         @test isbranch(g1) == false
         @test ischain(g1)
-        # @test isfactorless(g1)
-        # @test isfactorless(g2) == false
         @test_throws AssertionError eldest(g1)
         @test count_operation(g1) == [0, 0]
         @test count_operation(g2) == [0, 0]
@@ -1105,9 +1076,6 @@ end
         @test isleaf(g3) == false
         @test isbranch(g3)
         @test ischain(g3)
-        # @test isfactorless(g3)
-        # @test isfactorless(g4)
-        # @test isfactorless(g5) == false
         @test isleaf(eldest(g3))
         @test has_zero_subfactors(h1)
     end
@@ -1117,8 +1085,6 @@ end
         @test isleaf(g6) == false
         @test isbranch(g6) == false
         @test ischain(g6)
-        # @test isfactorless(g6)
-        # @test isfactorless(g7) == false
         @test isbranch(eldest(g6))
     end
     @testset "General" begin
@@ -1127,7 +1093,6 @@ end
         @test isleaf(g8) == false
         @test isbranch(g8) == false
         @test ischain(g8) == false
-        # @test isfactorless(g8) == false
         @test onechild(eldest(g8)) == false
         @test count_operation(g8) == [1, 0]
         @test count_operation(g9) == [2, 0]

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -44,7 +44,7 @@
     @test parity5 == 1
 end
 
-@testset "feynman_diagram from Wick"
+@testset "feynman_diagram from Wick" begin
     # construct Feynman diagram from FeynmanGraphs
     g1 = ComputationalGraphs.propagator(𝑓⁺(1)𝑓⁻(2),)
     g2 = ComputationalGraphs.propagator(𝑓⁺(2)𝑓⁻(1),)

--- a/test/quantum_operator.jl
+++ b/test/quantum_operator.jl
@@ -74,3 +74,19 @@ end
     @test QuantumOperators.parity(p4) == -1
     @test QuantumOperators.parity_old(p4) == -1
 end
+
+@testset "String representations" begin
+    @testset "Operator" begin
+        o = QuantumOperator(QuantumOperators.Majorana(), 1)
+        @test repr(o) == "f(1)"
+        @test string(o) == "Majorana(1)"
+    end
+    @testset "OperatorProduct" begin
+        op1 = OperatorProduct(QuantumOperator(QuantumOperators.Majorana(), 1))
+        @test repr(op1) == "f(1)"
+        @test string(op1) == "Majorana(1)"
+        op2 = 𝑓⁺(1)𝑓⁻(2)
+        @test repr(op2) == "f⁺(1)f⁻(2)"
+        @test string(op2) == "FermiCreation(1)FermiAnnihilation(2)"
+    end
+end


### PR DESCRIPTION
1. Add getter `properties` and setter `set_properties!` to `AbstractGraph` interface. This fixes a bug in I/O for user-defined concrete graph types such as the example `ConcreteGraph` defined in the test set.
2. Improve string representations for graphs, Feynman graphs, and operators.
3. Add plaintext representations for all custom graph, operator, and quantum operator symbols.
4. Bugfix for `typestr` in function `_stringrep` to correctly display subgraph IDs (see examples below).
5. Add tests for all string representations.
6. Clean up comments in tests and `tree_properties.jl`.

For example, the code
```julia
using AbstractTrees, FeynmanDiagram

ComputationalGraphs.uidreset();
g = 2 * (Graph([]) + Graph([]));

function display(g)
    println("plaintext:\n", g)  # plaintext representation
    println("\nREPL:")
    show(g)                     # decorated representation shown by the REPL
    println("\n\nAbstractTrees:")
    print_tree(g)
end

display(g)
```
now produces the output:
```julia
plaintext:
4: Prod(3)=0.0

REPL:
4: Ⓧ (3)=0.0

AbstractTrees:
4: Ⓧ (3)=0.0
└─ 3: ⨁(1,2)=0.0
   ├─ 1: 0.0
   └─ 2: 0.0
```
instead of 
```julia
plaintext:
4=0.0=FeynmanDiagram.ComputationalGraphs.Prod 

REPL:
4=0.0=FeynmanDiagram.ComputationalGraphs.Prod 

AbstractTrees:
4 : 4=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
└─ 3 : 3=0.0=FeynmanDiagram.ComputationalGraphs.Sum 
   ├─ 1 : 1=0.0()
   └─ 2 : 2=0.0()
```

Similarly, the code
```julia
using AbstractTrees
using FeynmanDiagram
import FeynmanDiagram.FrontEnds: NoHartree

ComputationalGraphs.uidreset();
para = Parquet.DiagPara(type=Parquet.SigmaDiag, innerLoopNum=2, hasTau=true, filter=[NoHartree,]);
sigma2_ins = optimize!(Parquet.build(para).diagram)[1];
dict_sigma2_AD = taylorAD(
    [sigma2_ins], 
    [1, 0],
    [x -> x isa FrontEnds.BareGreenId, x -> x isa FrontEnds.BareInteractionId],
);
dmu_sigma2 = dict_sigma2_AD[[1, 0]][1];
print_tree(dmu_sigma2; maxdepth=7)
```
now produces the output
```julia
126: Ins, k[1.0, 0.0, 0.0], t(1, 1)[1]=Ⓧ (124)=0.0
└─ 124: Ins, k[1.0, 0.0, 0.0], t(1, 1)[1]=Ⓧ (119,1)=0.0
   ├─ 119: Dyn, k[0.0, 1.0, 0.0], t(1, 1)[1]=⨁(117,118)=0.0
   │  ├─ 117: [1]=Ⓧ (7,111)=0.0
   │  │  ├─ 7: g0, Dyn, k[0.0, 1.0, 0.0], t(1, 2)=0.0
   │  │  └─ 111: (t = (2, 1),)[1]=⨁(109,110)=0.0
   │  │     ├─ 109: [1]=Ⓧ (99,103)=0.0
   │  │     │  ├─ 99: Ins, k[0.0, 1.0, 0.0], t(2, 2)=Ⓧ (14,8)=0.0
   │  │     │  │  ├─ 14: Gfock, Dyn, k[0.0, 0.0, 1.0], t(2, 2)=0.0
   │  │     │  │  └─ 8: ccIns, k[0.0, 1.0, -1.0], t(1, 1)=0.0
   │  │     │  └─ 103: Dyn, k[0.0, 1.0, 0.0], t(2, 1)[1]=0.0
   │  │     └─ 110: [1]=Ⓧ (100,21)=0.0
   │  │        ├─ 100: Ins, k[0.0, 1.0, 0.0], t(2, 2)[1]=Ⓧ (95,8)=0.0
   │  │        │  ├─ 95: Dyn, k[0.0, 0.0, 1.0], t(2, 2)[1]=0.0
   │  │        │  └─ 8: ccIns, k[0.0, 1.0, -1.0], t(1, 1)=0.0
   │  │        └─ 21: G, Dyn, k[0.0, 1.0, 0.0], t(2, 1)=0.0
   │  └─ 118: [1]=Ⓧ (94,108)=0.0
   │     ├─ 94: Dyn, k[0.0, 1.0, 0.0], t(1, 2)[1]=0.0
   │     └─ 108: (t = (2, 1),)=Ⓧ (99,21)=0.0
   │        ├─ 99: Ins, k[0.0, 1.0, 0.0], t(2, 2)=Ⓧ (14,8)=0.0
   │        │  ├─ 14: Gfock, Dyn, k[0.0, 0.0, 1.0], t(2, 2)=0.0
   │        │  └─ 8: ccIns, k[0.0, 1.0, -1.0], t(1, 1)=0.0
   │        └─ 21: G, Dyn, k[0.0, 1.0, 0.0], t(2, 1)=0.0
   └─ 1: ccIns, k[1.0, -1.0, 0.0], t(1, 1)=0.0
```
instead of
```julia
126 : 126Ins, k[1.0, 0.0, 0.0], t(1, 1)[1]=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
└─ 124 : 124Ins, k[1.0, 0.0, 0.0], t(1, 1)[1]=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   ├─ 119 : 119Dyn, k[0.0, 1.0, 0.0], t(1, 1)[1]=0.0=FeynmanDiagram.ComputationalGraphs.Sum 
   │  ├─ 117 : 117[1]=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   │  │  ├─ 7 : 7-g0Dyn, k[0.0, 1.0, 0.0], t(1, 2)=0.0()
   │  │  └─ 111 : 111(t = (2, 1),)[1]=0.0=FeynmanDiagram.ComputationalGraphs.Sum 
   │  │     ├─ 109 : 109[1]=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   │  │     │  ├─ 99 : 99Ins, k[0.0, 1.0, 0.0], t(2, 2)=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   │  │     │  │  ├─ 14 : 14-GfockDyn, k[0.0, 0.0, 1.0], t(2, 2)=0.0()
   │  │     │  │  └─ 8 : 8ccIns, k[0.0, 1.0, -1.0], t(1, 1)=0.0()
   │  │     │  └─ 103 : 103Dyn, k[0.0, 1.0, 0.0], t(2, 1)[1]=0.0()
   │  │     └─ 110 : 110[1]=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   │  │        ├─ 100 : 100Ins, k[0.0, 1.0, 0.0], t(2, 2)[1]=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   │  │        │  ├─ 95 : 95Dyn, k[0.0, 0.0, 1.0], t(2, 2)[1]=0.0()
   │  │        │  └─ 8 : 8ccIns, k[0.0, 1.0, -1.0], t(1, 1)=0.0()
   │  │        └─ 21 : 21-GDyn, k[0.0, 1.0, 0.0], t(2, 1)=0.0()
   │  └─ 118 : 118[1]=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   │     ├─ 94 : 94Dyn, k[0.0, 1.0, 0.0], t(1, 2)[1]=0.0()
   │     └─ 108 : 108(t = (2, 1),)=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   │        ├─ 99 : 99Ins, k[0.0, 1.0, 0.0], t(2, 2)=0.0=FeynmanDiagram.ComputationalGraphs.Prod 
   │        │  ├─ 14 : 14-GfockDyn, k[0.0, 0.0, 1.0], t(2, 2)=0.0()
   │        │  └─ 8 : 8ccIns, k[0.0, 1.0, -1.0], t(1, 1)=0.0()
   │        └─ 21 : 21-GDyn, k[0.0, 1.0, 0.0], t(2, 1)=0.0()
   └─ 1 : 1ccIns, k[1.0, -1.0, 0.0], t(1, 1)=0.0()
```