### PR TITLE
Fix Julia 1.12 compatibility and restore CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   - push
   - pull_request
+  - workflow_dispatch
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -31,9 +32,9 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v7
         with:
-          file: lcov.info
+          files: lcov.info
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,30 +10,24 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          # - "1.6"
+          - "1.6"
           # - "nightly"
           - "1.9"
+          - "1.10"
+          - "1.11"
+          - "1.12"
         os:
           - ubuntu-latest
         arch:
           - x64
           # - x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -44,8 +38,8 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
       - run: |

--- a/src/computational_graph/abstractgraph.jl
+++ b/src/computational_graph/abstractgraph.jl
@@ -20,13 +20,25 @@ Base.print(io::IO, o::AbstractOperator) = print(io, typeof(o))
 Base.print(io::IO, ::Type{Sum}) = print(io, "Sum")
 Base.print(io::IO, ::Type{Prod}) = print(io, "Prod")
 Base.print(io::IO, ::Type{Unitary}) = print(io, "Unitary")
-Base.print(io::IO, ::Type{Power{N}}) where {N} = print(io, "Power{$N}")
+function Base.print(io::IO, P::Type{<:Power})
+    if isconcretetype(P)
+        print(io, "Power{", eltype(P), "}")
+    else
+        print(io, "Power")
+    end
+end
 
 Base.show(io::IO, o::AbstractOperator) = print(io, typeof(o))
 Base.show(io::IO, ::Type{Sum}) = print(io, "⨁")
 Base.show(io::IO, ::Type{Prod}) = print(io, "Ⓧ ")
 Base.show(io::IO, ::Type{Unitary}) = print(io, "𝟙")
-Base.show(io::IO, ::Type{Power{N}}) where {N} = print(io, "^$N")
+function Base.show(io::IO, P::Type{<:Power})
+    if isconcretetype(P)
+        print(io, "^", eltype(P))
+    else
+        print(io, "Power")
+    end
+end
 
 # Is the unary form of operator 𝓞 trivial: 𝓞(G) ≡ G?
 # NOTE: this property implies that 𝓞(c * G) = c * G = c * 𝓞(G), so

--- a/src/frontend/GV_diagrams/readfile.jl
+++ b/src/frontend/GV_diagrams/readfile.jl
@@ -173,7 +173,7 @@ function read_diagrams(filename::AbstractString; labelProd::Union{Nothing,LabelP
         gr = _group(diagrams, extT_labels)
         unique!(extT_labels)
         graphvec = FeynmanGraph[]
-        staticextT_idx = findfirst(allequal, extT_labels)
+        staticextT_idx = findfirst(IR.alleq, extT_labels)
         if staticextT_idx > 1
             extT_labels[staticextT_idx], extT_labels[1] = extT_labels[1], extT_labels[staticextT_idx]
         end

--- a/src/frontend/parquet/benchmark/vertex4_eval.jl
+++ b/src/frontend/parquet/benchmark/vertex4_eval.jl
@@ -25,7 +25,7 @@ end
 #     end
 # end
 
-function eval(para, ver4::Ver4, varK, varT, legK, evalG::Function, evalV::Function, fast=false; kwargs...)
+function eval!(para, ver4::Ver4, varK, varT, legK, evalG::Function, evalV::Function, fast=false; kwargs...)
     KinL, KoutL, KinR, KoutR = legK
     spin = para.spin
     T0idx = para.firstTauIdx
@@ -93,15 +93,15 @@ function eval(para, ver4::Ver4, varK, varT, legK, evalG::Function, evalV::Functi
         end
 
         if c == T
-            eval(para, b.Lver, varK, varT, [KinL, KoutL, Kt, K], evalG, evalV; kwargs...)
-            eval(para, b.Rver, varK, varT, [K, Kt, KinR, KoutR], evalG, evalV; kwargs...)
+            eval!(para, b.Lver, varK, varT, [KinL, KoutL, Kt, K], evalG, evalV; kwargs...)
+            eval!(para, b.Rver, varK, varT, [K, Kt, KinR, KoutR], evalG, evalV; kwargs...)
         elseif c == U
-            eval(para, b.Lver, varK, varT, [KinL, KoutR, Ku, K], evalG, evalV; kwargs...)
-            eval(para, b.Rver, varK, varT, [K, Ku, KinR, KoutL], evalG, evalV; kwargs...)
+            eval!(para, b.Lver, varK, varT, [KinL, KoutR, Ku, K], evalG, evalV; kwargs...)
+            eval!(para, b.Rver, varK, varT, [K, Ku, KinR, KoutL], evalG, evalV; kwargs...)
         elseif c == S
             # S channel
-            eval(para, b.Lver, varK, varT, [KinL, Ks, KinR, K], evalG, evalV; kwargs...)
-            eval(para, b.Rver, varK, varT, [K, KoutL, Ks, KoutR], evalG, evalV; kwargs...)
+            eval!(para, b.Lver, varK, varT, [KinL, Ks, KinR, K], evalG, evalV; kwargs...)
+            eval!(para, b.Rver, varK, varT, [K, KoutL, Ks, KoutR], evalG, evalV; kwargs...)
         else
             error("not implemented")
         end

--- a/test/computational_graph.jl
+++ b/test/computational_graph.jl
@@ -76,6 +76,11 @@ Graphs.unary_istrivial(::Type{O}) where {O<:Union{O1,O2,O3}} = true
         @test string(g) == repr(g) == "4: black=O(1,2,3)=1.0"
         @test string(gp) == repr(gp) == "5: black=O(1,2,3)=1.0"
         @test string(h) == repr(h) == "6: h, black=O(1,2,3)=1.0"
+        @test sprint(show, Graphs.Power{2}) == "^2"
+        @test sprint(show, Graphs.Power) == "Power"
+        @test sprint(print, Graphs.Power{2}) == "Power{2}"
+        @test sprint(print, Graphs.Power) == "Power"
+        @test occursin("Power", string(which(show, (IO, Type{Graphs.Power{2}})).sig))
     end
     @testset "Traits" begin
         @test Graphs.unary_istrivial(g1) == true
@@ -1149,4 +1154,3 @@ end
         @test count_post == 5
     end
 end
-

--- a/test/front_end.jl
+++ b/test/front_end.jl
@@ -445,6 +445,7 @@ end
 
     @testset "ParquetNew Ver4" begin
         Benchmark = Parquet.Benchmark
+        @test isdefined(Benchmark, :eval!)
 
         function getfunction(type)
             if type == :physical
@@ -549,15 +550,15 @@ end
 
                 KinL, KoutL, KinR, KoutR = varK[:, 1], varK[:, 1], varK[:, 2], varK[:, 2]
                 legK = [KinL, KoutL, KinR, KoutR]
-                # Benchmark.eval(para, ver4, varK, varT, [KinL, KoutL, KinR, KoutR], evalG, evalV, true)
-                Benchmark.eval(para, ver4, varK, varT, legK, evalG, evalV, true)
+                # Benchmark.eval!(para, ver4, varK, varT, [KinL, KoutL, KinR, KoutR], evalG, evalV, true)
+                Benchmark.eval!(para, ver4, varK, varT, legK, evalG, evalV, true)
 
                 if timing
                     printstyled("parquet evaluator cost:", color=:green)
                     # @btime sin(p, ver4, var) setup = (x = rand())
-                    # @time Benchmark.eval(para, ver4, varK, varT, [KinL, KoutL, KinR, KoutR], evalG, evalV, true)
-                    @time Benchmark.eval(para, ver4, varK, varT, legK, evalG, evalV, true)
-                    # @btime Benchmark.eval(p, v4, vK, vT, lK, eG, eV, flag) setup = (p = para, v4 = ver4, vK = varK, vT = varT, l = legK, eG = evalG, eV = evalV, flag = true)
+                    # @time Benchmark.eval!(para, ver4, varK, varT, [KinL, KoutL, KinR, KoutR], evalG, evalV, true)
+                    @time Benchmark.eval!(para, ver4, varK, varT, legK, evalG, evalV, true)
+                    # @btime Benchmark.eval!(p, v4, vK, vT, lK, eG, eV, flag) setup = (p = para, v4 = ver4, vK = varK, vT = varT, l = legK, eG = evalG, eV = evalV, flag = true)
                 end
 
                 w2 = ver4.weight[1]


### PR DESCRIPTION
Julia 1.12 changed the implicit module eval binding, so defining Benchmark.eval now fails while loading FeynmanDiagram. This change renames that internal, unexported evaluator to Benchmark.eval! and updates all recursive and test call sites.

It also fixes a latent Power display-method bug exposed while traversing method signatures: the old free TypeVar signature could fail while Julia stringified method metadata. The new methods handle both concrete Power{N} types and the Power UnionAll, with direct regressions for method-signature introspection.

Restoring the declared Julia 1.6 CI floor exposed one existing call to Base.allequal, which is unavailable before Julia 1.8 even though the package already carries an alleq backport. The GV reader now uses that existing backport; the previously failing Taylor test exercises it.

CI is restored by replacing retired GitHub Actions and now tests the declared Julia 1.6 lower bound plus Julia 1.9, 1.10, 1.11, and 1.12.

Compatibility note: downstream code calling the non-exported Benchmark.eval helper must use Benchmark.eval! after this release.

Closes #185.