### PR TITLE
Release v1.0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FeynmanDiagram"
 uuid = "e424a512-dbd9-41ff-9883-094748823e72"
 authors = ["Kun Chen", "Pengcheng Hou", "Daniel Cerkoney"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Release the Julia compatibility fixes delivered by #191.

This release:
- supports Julia 1.12 module evaluation semantics via the internal Benchmark.eval! helper
- makes Power type display safe during method-signature reflection
- restores the declared Julia 1.6 floor by using the package existing alleq backport
- carries the validated Julia 1.6, 1.9, 1.10, 1.11, and 1.12 CI matrix

This PR intentionally changes only Project.toml version from 1.0.2 to 1.0.3 so the release commit does not modify GitHub workflow files.